### PR TITLE
Favorite support.

### DIFF
--- a/ownCloudSDK/Connection/OCConnection.m
+++ b/ownCloudSDK/Connection/OCConnection.m
@@ -505,6 +505,7 @@
 			[OCXMLNode elementWithName:@"size" attributes:@[[OCXMLNode namespaceWithName:nil stringValue:@"http://owncloud.org/ns"]]],
 			[OCXMLNode elementWithName:@"id" attributes:@[[OCXMLNode namespaceWithName:nil stringValue:@"http://owncloud.org/ns"]]],
 			[OCXMLNode elementWithName:@"permissions" attributes:@[[OCXMLNode namespaceWithName:nil stringValue:@"http://owncloud.org/ns"]]],
+            [OCXMLNode elementWithName:@"favorite" attributes:@[[OCXMLNode namespaceWithName:nil stringValue:@"http://owncloud.org/ns"]]],
 		]];
 
 		// OCLog(@"%@", davRequest.xmlRequest.XMLString);

--- a/ownCloudSDK/Core/OCCore.m
+++ b/ownCloudSDK/Core/OCCore.m
@@ -589,7 +589,7 @@
 		if (cacheUpdateError != nil)
 		{
 			// An error occured updating the cache, so don't update queries either, log the error and return here
-			OCLogError(@"Error updating metaData cache: %@", cacheUpdateError);
+            OCLogError(@"Error updating metaData cache: %@", cacheUpdateError);
 			return;
 		}
 	}

--- a/ownCloudSDK/Item/OCItem.h
+++ b/ownCloudSDK/Item/OCItem.h
@@ -94,6 +94,8 @@ typedef NS_ENUM(NSInteger, OCItemThumbnailAvailability)
 
 @property(strong) OCDatabaseID databaseID; //!< OCDatabase-specific ID referencing the item in the database (ephermal!)
 
+@property(assign) BOOL favorite; //!< If the Item has been selected favorite in the server.
+
 #pragma mark - Serialization tools
 + (instancetype)itemFromSerializedData:(NSData *)serializedData;
 - (NSData *)serializedData;

--- a/ownCloudSDK/Item/OCItem.m
+++ b/ownCloudSDK/Item/OCItem.m
@@ -67,6 +67,8 @@
 	[coder encodeObject:_lastModified	forKey:@"lastModified"];
 
 	[coder encodeObject:_shares		forKey:@"shares"];
+
+    [coder encodeBool:_favorite forKey:@"favorite"];
 }
 
 #pragma mark - Init & Dealloc
@@ -108,6 +110,8 @@
 		_lastModified = [decoder decodeObjectOfClass:[NSDate class] forKey:@"lastModified"];
 
 		_shares = [decoder decodeObjectOfClass:[NSArray class] forKey:@"shares"];
+
+        _favorite = [decoder decodeBoolForKey:@"favorite"];
 	}
 
 	return (self);

--- a/ownCloudSDK/Vaults/Database/OCDatabase.m
+++ b/ownCloudSDK/Vaults/Database/OCDatabase.m
@@ -131,7 +131,8 @@
 			@"parentPath" 		: [item.path stringByDeletingLastPathComponent],
 			@"name"			: [item.path lastPathComponent],
 			@"fileID"		: item.fileID,
-			@"itemData"		: [item serializedData]
+			@"itemData"		: [item serializedData],
+            @"favorite"     : @(item.favorite)
 		} resultHandler:^(OCSQLiteDB *db, NSError *error, NSNumber *rowID) {
 			item.databaseID = rowID;
 		}]];
@@ -158,7 +159,8 @@
 				@"parentPath" 		: [item.path stringByDeletingLastPathComponent],
 				@"name"			: [item.path lastPathComponent],
 				@"fileID"		: item.fileID,
-				@"itemData"		: [item serializedData]
+				@"itemData"		: [item serializedData],
+                @"favorite"     : @(item.favorite)
 			} completionHandler:nil]];
 		}
 		else

--- a/ownCloudSDK/XML/Parsing/OCItem+OCXMLObjectCreation.m
+++ b/ownCloudSDK/XML/Parsing/OCItem+OCXMLObjectCreation.m
@@ -71,6 +71,17 @@
 				}
 			} copy],
 
+            @"oc:favorite" : [^(OCItem *item, NSString *key, id value) {
+                if ([value isKindOfClass:[NSString class]])
+                {
+                    if (((NSString *)value).integerValue == 1) {
+                        item.favorite = YES;
+                    } else {
+                        item.favorite = NO;
+                    }
+                }
+            } copy],
+
 			@"oc:permissions" : [^(OCItem *item, NSString *key, id value) {
 				if ([value isKindOfClass:[NSString class]])
 				{


### PR DESCRIPTION
The aim with this PR is to make the sdk able to retrieve the `oc:favorite` value from each item in the `PROPFIND` request.

I've added this new property to the database, so now the database version is 3.

This PR cover some parts of what is proposed in https://github.com/owncloud/ios-sdk/issues/15

 