### PR TITLE
Hotfix/fix spanish translation

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -3,14 +3,14 @@ host = https://www.transifex.com
 
 [owncloud.mobile-ios-sdk]
 file_filter = ownCloudSDK/Resources/<lang>.lproj/Localizable.strings
-lang_map = es_ES: es, cs_CZ: cs, de: de, de_DE: de-DE, en_GB: en-GB, nb_NO: nb-NO, nn_NO: nn-NO, pt_PT: pt-PT, pt_BR: pt-BR, zh_CN: zh-Hans, th_TH: th-TH
+lang_map = cs_CZ: cs, de: de, de_DE: de-DE, en_GB: en-GB, nb_NO: nb-NO, nn_NO: nn-NO, pt_PT: pt-PT, pt_BR: pt-BR, zh_CN: zh-Hans, th_TH: th-TH
 source_file = ownCloudSDK/Resources/en.lproj/Localizable.strings
 source_lang = en
 type = STRINGS
 
 [owncloud.mobile-ios-ui]
 file_filter = ownCloudUI/Resources/<lang>.lproj/Localizable.strings
-lang_map = es_ES: es, cs_CZ: cs, de: de, de_DE: de-DE, en_GB: en-GB, nb_NO: nb-NO, nn_NO: nn-NO, pt_PT: pt-PT, pt_BR: pt-BR, zh_CN: zh-Hans, th_TH: th-TH
+lang_map = cs_CZ: cs, de: de, de_DE: de-DE, en_GB: en-GB, nb_NO: nb-NO, nn_NO: nn-NO, pt_PT: pt-PT, pt_BR: pt-BR, zh_CN: zh-Hans, th_TH: th-TH
 source_file = ownCloudUI/Resources/en.lproj/Localizable.strings
 source_lang = en
 type = STRINGS


### PR DESCRIPTION
## Description
Removed the mapping of the Spanish language because was wrong and it is not necessary. "es" from TX is "es" also on the xcode project.

## Motivation and Context
Include all the finished translations on the first release of ownCloud iOS App

## How Has This Been Tested?
After be merge Drone should update the file automatically

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
