### PR TITLE
[fix/unauthorized] Improve handling of unexpected 401 UNAUTHORIZED responses in OAuth2

### DIFF
--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -67,3 +67,25 @@ Pre-requisites:
 `mitmweb --web-port 10001 --listen-port 443 --mode reverse:http://localhost:36080 --set keep_host_header --cert "*=cert-pkey-B-cert1.pem"`
 
 The OC instance is then accessible via `https://localhost:443/` by the app in the Simulator.
+
+## Testing OAuth2
+Pre-requisites:
+- running a simple instance as described above
+- install OAuth2 plugin in the instance via OC Market
+- create new OAuth2-based bookmark for instance
+
+### Listing access tokens
+`docker-compose exec owncloud sqlite3 /mnt/data/files/owncloud.db "SELECT * FROM oc_oauth2_access_tokens"`
+
+### Listing refresh tokens
+`docker-compose exec owncloud sqlite3 /mnt/data/files/owncloud.db "SELECT * FROM oc_oauth2_refresh_tokens"`
+
+### Deleting access tokens
+`docker-compose exec owncloud sqlite3 /mnt/data/files/owncloud.db "DELETE FROM oc_oauth2_access_tokens"`
+
+### Deleting refresh tokens
+`docker-compose exec owncloud sqlite3 /mnt/data/files/owncloud.db "DELETE FROM oc_oauth2_refresh_tokens"`
+
+### Deleting all tokens
+`docker-compose exec owncloud sqlite3 /mnt/data/files/owncloud.db "DELETE FROM oc_oauth2_access_tokens; DELETE FROM oc_oauth2_refresh_tokens;"`
+

--- a/ownCloudSDK/Authentication/OCAuthenticationMethod+OCTools.h
+++ b/ownCloudSDK/Authentication/OCAuthenticationMethod+OCTools.h
@@ -16,14 +16,19 @@
  *
  */
 
-#import <ownCloudSDK/ownCloudSDK.h>
+#import "OCConnection.h"
+#import "OCAuthenticationMethod.h"
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface OCAuthenticationMethod (OCTools)
 
 + (NSString *)basicAuthorizationValueForUsername:(NSString *)username passphrase:(NSString *)passPhrase;
 
-+ (NSArray <NSURL *> *)detectionURLsBasedOnWWWAuthenticateMethod:(NSString *)wwwAuthenticateMethod forConnection:(OCConnection *)connection;
++ (nullable NSArray <NSURL *> *)detectionURLsBasedOnWWWAuthenticateMethod:(NSString *)wwwAuthenticateMethod forConnection:(OCConnection *)connection;
 
-+ (void)detectAuthenticationMethodSupportBasedOnWWWAuthenticateMethod:(NSString *)wwwAuthenticateMethod forConnection:(OCConnection *)connection withServerResponses:(NSDictionary<NSURL *, OCHTTPRequest *> *)serverResponses completionHandler:(void(^)(OCAuthenticationMethodIdentifier identifier, BOOL supported))completionHandler;
++ (void)detectAuthenticationMethodSupportBasedOnWWWAuthenticateMethod:(NSString *)wwwAuthenticateMethod forConnection:(OCConnection *)connection withServerResponses:(NSDictionary<NSURL *, OCHTTPRequest *> *)serverResponses completionHandler:(void(^)(OCAuthenticationMethodIdentifier _Nullable identifier, BOOL supported))completionHandler;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ownCloudSDK/Authentication/OCAuthenticationMethod.h
+++ b/ownCloudSDK/Authentication/OCAuthenticationMethod.h
@@ -30,7 +30,9 @@ typedef NSString* OCAuthenticationMethodKey NS_TYPED_ENUM; //!< NSString key use
 typedef NSDictionary<OCAuthenticationMethodKey,id>* OCAuthenticationMethodBookmarkAuthenticationDataGenerationOptions; //!< Dictionary with options used to generate the authentication data for a bookmark. F.ex. passwords or the view controller to attach own UI to.
 typedef NSDictionary<OCAuthenticationMethodKey,id>* OCAuthenticationMethodDetectionOptions; //!< Dictionary with options used to detect available authentication methods
 
-typedef void(^OCAuthenticationMethodAuthenticationCompletionHandler)(NSError *error, OCIssue *issue);
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void(^OCAuthenticationMethodAuthenticationCompletionHandler)(NSError * _Nullable error, OCIssue * _Nullable issue);
 
 typedef NS_ENUM(NSUInteger, OCAuthenticationMethodType)
 {
@@ -48,21 +50,21 @@ typedef NS_ENUM(NSUInteger, OCAuthenticationMethodType)
 + (void)registerAuthenticationMethodClass:(Class)authenticationMethodClass; //!< Add an authentication method to the core
 + (void)unregisterAuthenticationMethodClass:(Class)authenticationMethodClass; //!< Add an authentication method to the core
 + (NSArray <Class> *)registeredAuthenticationMethodClasses; //!< Array of registered authentication method classes
-+ (Class)registeredAuthenticationMethodForIdentifier:(OCAuthenticationMethodIdentifier)identifier; //!< Returns the OCAuthenticationMethod class for identifier
++ (nullable Class)registeredAuthenticationMethodForIdentifier:(OCAuthenticationMethodIdentifier)identifier; //!< Returns the OCAuthenticationMethod class for identifier
 
 #pragma mark - Identification
-+ (OCAuthenticationMethodType)type;
-+ (OCAuthenticationMethodIdentifier)identifier;
-+ (NSString *)name;
-- (NSString *)name;
+@property(readonly,assign,class,nonatomic) OCAuthenticationMethodType type;
+@property(readonly,strong,class,nonatomic,nonnull) OCAuthenticationMethodIdentifier identifier;
+@property(readonly,strong,class,nonatomic,nonnull) NSString *name;
+@property(readonly,strong,nonatomic,nonnull) NSString *name;
 
 #pragma mark - Authentication Data Access
 @property(readonly,class,nonatomic) BOOL usesUserName; //!< This authentication method uses a user name (passphrase-based only)
-+ (NSString *)userNameFromAuthenticationData:(NSData *)authenticationData; //!< Returns the user name stored inside authenticationData
-+ (NSString *)passPhraseFromAuthenticationData:(NSData *)authenticationData; //!< Returns the passphrase stored inside authenticationData (passphrase-based only)
++ (nullable NSString *)userNameFromAuthenticationData:(NSData *)authenticationData; //!< Returns the user name stored inside authenticationData
++ (nullable NSString *)passPhraseFromAuthenticationData:(NSData *)authenticationData; //!< Returns the passphrase stored inside authenticationData (passphrase-based only)
 
 #pragma mark - Authentication Method Detection
-+ (NSArray <NSURL *> *)detectionURLsForConnection:(OCConnection *)connection; //!< Provides a list of URLs whose content is needed to determine whether this authentication method is supported
++ (nullable NSArray <NSURL *> *)detectionURLsForConnection:(OCConnection *)connection; //!< Provides a list of URLs whose content is needed to determine whether this authentication method is supported
 + (void)detectAuthenticationMethodSupportForConnection:(OCConnection *)connection withServerResponses:(NSDictionary<NSURL *, OCHTTPRequest *> *)serverResponses options:(OCAuthenticationMethodDetectionOptions)options completionHandler:(void(^)(OCAuthenticationMethodIdentifier identifier, BOOL supported))completionHandler; //!< Detects authentication method support using collected responses (for URL provided by -detectionURLsForConnection:) and then returns result via the completionHandler.
 
 #pragma mark - Authentication / Deauthentication ("Login / Logout")
@@ -71,21 +73,21 @@ typedef NS_ENUM(NSUInteger, OCAuthenticationMethodType)
 
 - (OCHTTPRequest *)authorizeRequest:(OCHTTPRequest *)request forConnection:(OCConnection *)connection; //!< Applies all necessary modifications to a request so that it's authorized using this authentication method. This can be adding tokens, passwords, etc. to the headers. The request returned by this method is sent. The default implementation applies the headers returned by -authorizationHeadersForConnection:error:.
 
-- (NSDictionary<NSString *, NSString *> *)authorizationHeadersForConnection:(OCConnection *)connection error:(NSError **)outError; //!< For authentication methods based on HTTP headers, returns a dictionary of the authorization headers. nil and an error otherwise.
+- (nullable NSDictionary<NSString *, NSString *> *)authorizationHeadersForConnection:(OCConnection *)connection error:(NSError **)outError; //!< For authentication methods based on HTTP headers, returns a dictionary of the authorization headers. nil and an error otherwise.
 
 #pragma mark - Generate bookmark authentication data
-- (void)generateBookmarkAuthenticationDataWithConnection:(OCConnection *)connection options:(OCAuthenticationMethodBookmarkAuthenticationDataGenerationOptions)options completionHandler:(void(^)(NSError *error, OCAuthenticationMethodIdentifier authenticationMethodIdentifier, NSData *authenticationData))completionHandler; //!< Generates the authenticationData for a connection's bookmark and returns the result via the completionHandler. It is not directly stored in the bookmark so that an app can decide on its own when to overwrite existing data - or save the result. The authentication method is obligated to return an error in the completionHandler if authentication is not possible (f.ex. rejected token request, wrong username/passphrase).
+- (void)generateBookmarkAuthenticationDataWithConnection:(OCConnection *)connection options:(OCAuthenticationMethodBookmarkAuthenticationDataGenerationOptions)options completionHandler:(void(^)(NSError * _Nullable error, OCAuthenticationMethodIdentifier  _Nullable authenticationMethodIdentifier, NSData * _Nullable authenticationData))completionHandler; //!< Generates the authenticationData for a connection's bookmark and returns the result via the completionHandler. It is not directly stored in the bookmark so that an app can decide on its own when to overwrite existing data - or save the result. The authentication method is obligated to return an error in the completionHandler if authentication is not possible (f.ex. rejected token request, wrong username/passphrase).
 
 #pragma mark - Authentication Secret Caching
-- (id)cachedAuthenticationSecretForConnection:(OCConnection *)connection; //!< Method that allows an authentication method to cache a secret in memory. If none is present in memory, -loadCachedAuthenticationSecretForConnection: is called.
-- (id)loadCachedAuthenticationSecretForConnection:(OCConnection *)connection; //!< Called by -cachedAuthenticationSecretForConnection: if no authentication secret is stored in memory. Should retrieve and return the authentication secret for the connection.
+- (nullable id)cachedAuthenticationSecretForConnection:(OCConnection *)connection; //!< Method that allows an authentication method to cache a secret in memory. If none is present in memory, -loadCachedAuthenticationSecretForConnection: is called.
+- (nullable id)loadCachedAuthenticationSecretForConnection:(OCConnection *)connection; //!< Called by -cachedAuthenticationSecretForConnection: if no authentication secret is stored in memory. Should retrieve and return the authentication secret for the connection.
 - (void)flushCachedAuthenticationSecret; //!< Flushes the cached authentication secret. Called f.ex. if the device is locked or the user switches to another app.
 
 #pragma mark - Wait for authentication
 - (BOOL)canSendAuthenticatedRequestsForConnection:(OCConnection *)connection withAvailabilityHandler:(OCConnectionAuthenticationAvailabilityHandler)availabilityHandler; //!< This method is called by the -[OCConnection canSendAuthenticatedRequestsForQueue:availabilityHandler:] to determine if the authentication method is currently in the position to authenticate requests for the given connection. If it is, YES should be returned and the availabilityHandler shouldn't be used. If it is not (if, f.ex. a token has expired and needs to be renewed first), this method should return NO, attempt the necessary changes (if this involves scheduling requests, make sure these don't have OCConnectionSignalIDAuthenticationAvailable in their requiredSignals) and then call the availabilityHandler with the outcome. If an error is returned, all queued requests fail with the provided error.
 
 #pragma mark - Handle responses before they are delivered to the request senders
-- (NSError *)handleRequest:(OCHTTPRequest *)request response:(OCHTTPResponse *)response forConnection:(OCConnection *)connection withError:(NSError *)error; //!< This method is called for every finished request before the response gets delivered to the sender. Gives the authentication method a chance to get knowledge of and react to error infos contained in response
+- (nullable NSError *)handleRequest:(OCHTTPRequest *)request response:(OCHTTPResponse *)response forConnection:(OCConnection *)connection withError:(NSError *)error; //!< This method is called for every finished request before the response gets delivered to the sender. Gives the authentication method a chance to get knowledge of and react to error infos contained in response
 
 @end
 
@@ -101,6 +103,8 @@ extern OCAuthenticationMethodKey OCAuthenticationMethodPresentingViewControllerK
 extern OCAuthenticationMethodKey OCAuthenticationMethodAllowURLProtocolUpgradesKey; //!< Allow OCConnection to modify the OCBookmark with an upgraded URL, where an upgrade means that the hostname and base path must be identical and the protocol may only change from http to https. Any other change will be rejected and produce an OCErrorAuthorizationRedirect with userInfo[OCAuthorizationMethodAlternativeServerURLKey] for user approval (=> if the user approves, the app would update the URL in the bookmark accordingly and start authentication anew). This key is currently supported for
 
 extern NSString *OCAuthorizationMethodAlternativeServerURLKey; //!< Key for alternative server URL in -[NSError userInfo].
+
+NS_ASSUME_NONNULL_END
 
 #define OCAuthenticationMethodAutoRegister +(void)load{ \
 						[OCAuthenticationMethod registerAuthenticationMethodClass:self]; \

--- a/ownCloudSDK/Authentication/OCAuthenticationMethod.m
+++ b/ownCloudSDK/Authentication/OCAuthenticationMethod.m
@@ -82,12 +82,12 @@
 
 + (OCAuthenticationMethodIdentifier)identifier
 {
-	return (nil);
+	return ((id _Nonnull) nil); // Needs to be overridden by all subclasses. If one does not, let it crash.
 }
 
 + (NSString *)name
 {
-	return(nil);
+	return((id _Nonnull) nil); // Needs to be overridden by all subclasses. If one does not, let it crash.
 }
 
 - (NSString *)name

--- a/ownCloudSDK/Authentication/OCAuthenticationMethodBasicAuth.h
+++ b/ownCloudSDK/Authentication/OCAuthenticationMethodBasicAuth.h
@@ -18,10 +18,14 @@
 
 #import "OCAuthenticationMethod.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface OCAuthenticationMethodBasicAuth : OCAuthenticationMethod
 
-+ (NSData *)authenticationDataForUsername:(NSString *)userName passphrase:(NSString *)passPhrase authenticationHeaderValue:(NSString **)outAuthenticationHeaderValue error:(NSError **)outError; //!< Generates authentication data for basic auth without reaching out to the server. Useful for building tests. Should not be used for anything other than implementing tests.
++ (nullable NSData *)authenticationDataForUsername:(NSString *)userName passphrase:(NSString *)passPhrase authenticationHeaderValue:(NSString * _Nullable * _Nullable)outAuthenticationHeaderValue error:(NSError * _Nullable * _Nullable)outError; //!< Generates authentication data for basic auth without reaching out to the server. Useful for building tests. Should not be used for anything other than implementing tests.
 
 @end
 
 extern OCAuthenticationMethodIdentifier OCAuthenticationMethodIdentifierBasicAuth;
+
+NS_ASSUME_NONNULL_END

--- a/ownCloudSDK/Authentication/OCAuthenticationMethodOAuth2.m
+++ b/ownCloudSDK/Authentication/OCAuthenticationMethodOAuth2.m
@@ -313,8 +313,6 @@ OCAuthenticationMethodAutoRegister
 #pragma mark - Handle responses before they are delivered to the request senders
 - (NSError *)handleRequest:(OCHTTPRequest *)request response:(OCHTTPResponse *)response forConnection:(OCConnection *)connection withError:(NSError *)error
 {
-	NSError *error = nil;
-
 	if ((error = [super handleRequest:request response:response forConnection:connection withError:error]) != nil)
 	{
 		if (response.status.code == OCHTTPStatusCodeUNAUTHORIZED)
@@ -370,10 +368,19 @@ OCAuthenticationMethodAutoRegister
 						[self flushCachedAuthenticationSecret];
 					}
 
-					if (_receivedUnauthorizedResponse && (error!=nil))
+					if (self->_receivedUnauthorizedResponse)
 					{
-						// Token refresh following UNAUTHORIZED response failed
-						_tokenRefreshFollowingUnauthorizedResponseFailed = YES;
+						if (error != nil)
+						{
+							// Token refresh following UNAUTHORIZED response failed
+							self->_tokenRefreshFollowingUnauthorizedResponseFailed = YES;
+						}
+						else
+						{
+							// Token refresh fixed the issue
+							self->_receivedUnauthorizedResponse = NO;
+							self->_tokenRefreshFollowingUnauthorizedResponseFailed = NO;
+						}
 					}
 				
 					availabilityHandler(error, (error==nil));

--- a/ownCloudSDK/Connection/OCConnection+Authentication.m
+++ b/ownCloudSDK/Connection/OCConnection+Authentication.m
@@ -287,7 +287,7 @@
 
 - (OCAuthenticationMethod *)authenticationMethod
 {
-	if ((_authenticationMethod == nil) || ([[[_authenticationMethod class] identifier] isEqual:_bookmark.authenticationMethodIdentifier]))
+	if ((_authenticationMethod == nil) || (![[[_authenticationMethod class] identifier] isEqual:_bookmark.authenticationMethodIdentifier]))
 	{
 		self.authenticationMethod = [self _authenticationMethodWithIdentifier:_bookmark.authenticationMethodIdentifier];
 	}

--- a/ownCloudSDK/Connection/OCConnection.m
+++ b/ownCloudSDK/Connection/OCConnection.m
@@ -606,6 +606,12 @@ static OCConnectionSetupHTTPPolicy sSetupHTTPPolicy = OCConnectionSetupHTTPPolic
 {
 	OCHTTPRequestInstruction instruction = OCHTTPRequestInstructionDeliver;
 
+	if ([error isOCErrorWithCode:OCErrorAuthorizationRetry])
+	{
+		// Reschedule requested by auth method
+		instruction = OCHTTPRequestInstructionReschedule;
+	}
+
 	if ((_delegate!=nil) && [_delegate respondsToSelector:@selector(connection:instructionForFinishedRequest:withResponse:error:defaultsTo:)])
 	{
 		instruction = [_delegate connection:self instructionForFinishedRequest:task.request withResponse:task.response error:error defaultsTo:instruction];

--- a/ownCloudSDK/Core/Connection Status/OCCore+ConnectionStatus.m
+++ b/ownCloudSDK/Core/Connection Status/OCCore+ConnectionStatus.m
@@ -348,6 +348,15 @@
 				return (OCHTTPRequestInstructionReschedule);
 			}
 		}
+
+		// Authorization failed
+		if ([error isOCErrorWithCode:OCErrorAuthorizationFailed])
+		{
+			if ((_delegate!=nil) && [_delegate respondsToSelector:@selector(core:handleError:issue:)])
+			{
+				[_delegate core:self handleError:error issue:nil];
+			}
+		}
 	}
 
 	if (response.status.code == OCHTTPStatusCodeSERVICE_UNAVAILABLE)
@@ -359,6 +368,7 @@
 			return (OCHTTPRequestInstructionReschedule);
 		}
 	}
+
 
 	return (defaultInstruction);
 }

--- a/ownCloudSDK/Errors/NSError+OCError.h
+++ b/ownCloudSDK/Errors/NSError+OCError.h
@@ -88,7 +88,9 @@ typedef NS_ENUM(NSUInteger, OCError)
 
 	OCErrorInsufficientStorage, //!< Insufficient storage
 
-	OCErrorNotAvailableOffline //!< API not available offline.
+	OCErrorNotAvailableOffline, //!< API not available offline.
+
+	OCErrorAuthorizationRetry //!< Authorization failed. Retry the request.
 };
 
 @class OCIssue;

--- a/ownCloudSDK/Errors/NSError+OCError.m
+++ b/ownCloudSDK/Errors/NSError+OCError.m
@@ -260,6 +260,10 @@
 				case OCErrorNotAvailableOffline:
 					unlocalizedString = @"Not available offline.";
 				break;
+
+				case OCErrorAuthorizationRetry:
+					unlocalizedString = @"Authorization needs to be retried.";
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
## Description
   - Added OAuth2 token reset instructions to TESTING.md
   - Added nullability annotations to OCAuthenticationMethod and its subclasses
   - Turned OCAuthenticationMethod.type/.identifier/.name into real class properties for a more Swifty interface
   - Fix bug in OCConnection+Authentication that would create a new OCAuthenticationMethod instance for every request
   - Improve handling of OAuth2-related 401 responses
   - Fix issue in OCCoreItemListTask where a core activity would be registered before it's a safe bet that the end can be reached
   - Improve handling of unexpected 401 UNAUTHORIZED responses in OAuth2, OCConnection and OCCore

## Related Issue
https://github.com/owncloud/ios-app/issues/293

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
