### PR TITLE
[fix/at-uids] Add support for local users with @ inside their username

### DIFF
--- a/ownCloudSDK/Connection/OCConnection+Recipients.m
+++ b/ownCloudSDK/Connection/OCConnection+Recipients.m
@@ -45,8 +45,11 @@
 			switch ((OCShareType)shareTypeID.integerValue)
 			{
 				case OCShareTypeUserShare:
+					recipient = [[OCRecipient recipientWithUser:[OCUser userWithUserName:shareWith displayName:label isRemote:NO]] withSearchResultName:shareWithAdditionalInfo];
+				break;
+
 				case OCShareTypeRemote:
-					recipient = [[OCRecipient recipientWithUser:[OCUser userWithUserName:shareWith displayName:label]] withSearchResultName:shareWithAdditionalInfo];
+					recipient = [[OCRecipient recipientWithUser:[OCUser userWithUserName:shareWith displayName:label isRemote:YES]] withSearchResultName:shareWithAdditionalInfo];
 				break;
 
 				case OCShareTypeGroupShare:

--- a/ownCloudSDK/Connection/OCConnection+Users.m
+++ b/ownCloudSDK/Connection/OCConnection+Users.m
@@ -54,12 +54,13 @@
 
 			if (userInfoDict != nil)
 			{
-				OCUser *user = [OCUser new];
-
 				#define IgnoreNull(obj) ([obj isKindOfClass:[NSNull class]] ? nil : obj)
 
-				user.userName = IgnoreNull(userInfoDict[@"id"]);
-				user.displayName = IgnoreNull(userInfoDict[@"display-name"]);
+				OCUser *user;
+
+				user = [OCUser userWithUserName:IgnoreNull(userInfoDict[@"id"])
+						    displayName:IgnoreNull(userInfoDict[@"display-name"])
+						       isRemote:NO];
 				user.emailAddress = IgnoreNull(userInfoDict[@"email"]);
 
 				completionHandler(nil, user);

--- a/ownCloudSDK/Share/OCShare+OCXMLObjectCreation.m
+++ b/ownCloudSDK/Share/OCShare+OCXMLObjectCreation.m
@@ -121,9 +121,7 @@
 
 			if ((userNameFileOwner != nil) || (displayNameFileOwner != nil))
 			{
-				share.itemOwner = [OCUser new];
-				share.itemOwner.userName = userNameFileOwner;
-				share.itemOwner.displayName = displayNameFileOwner;
+				share.itemOwner = [OCUser userWithUserName:userNameFileOwner displayName:displayNameFileOwner];
 			}
 
 			// Item MIME Type
@@ -179,9 +177,7 @@
 
 			if ((userNameShareOwner != nil) || (displayNameShareOwner != nil))
 			{
-				share.owner = [OCUser new];
-				share.owner.userName = userNameShareOwner;
-				share.owner.displayName = displayNameShareOwner;
+				share.owner = [OCUser userWithUserName:userNameShareOwner displayName:displayNameShareOwner];
 			}
 			else
 			{
@@ -205,8 +201,7 @@
 						owner = [owner stringByAppendingFormat:@"@%@", remoteHost];
 					}
 
-					share.owner = [OCUser new];
-					share.owner.userName = owner;
+					share.owner = [OCUser userWithUserName:owner displayName:nil];
 				}
 			}
 

--- a/ownCloudSDK/Share/OCUser.h
+++ b/ownCloudSDK/Share/OCUser.h
@@ -23,6 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface OCUser : NSObject <NSSecureCoding, NSCopying>
 {
 	UIImage *_avatar;
+	NSNumber *_forceIsRemote;
 }
 
 @property(nullable,strong) NSString *displayName; //!< Display name of the user (f.ex. "John Appleseed")
@@ -40,6 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nullable,readonly,nonatomic) UIImage *avatar; //!< Avatar for the user (or nil if none is available) - auto-generated from avatarData, not archived
 
 + (instancetype)userWithUserName:(nullable NSString *)userName displayName:(nullable NSString *)displayName;
++ (instancetype)userWithUserName:(nullable NSString *)userName displayName:(nullable NSString *)displayName isRemote:(BOOL)isRemote;
 
 @end
 

--- a/ownCloudSDK/Share/OCUser.m
+++ b/ownCloudSDK/Share/OCUser.m
@@ -39,6 +39,17 @@
 	return (user);
 }
 
++ (instancetype)userWithUserName:(nullable NSString *)userName displayName:(nullable NSString *)displayName isRemote:(BOOL)isRemote
+{
+	OCUser *user = [OCUser new];
+
+	user.userName = userName;
+	user.displayName = displayName;
+	user->_forceIsRemote = @(isRemote);
+
+	return (user);
+}
+
 - (NSRange)_atRemoteRange
 {
 	NSRange atRange;
@@ -48,6 +59,12 @@
 	if ((atRange.location == 0) || (atRange.location == (_userName.length-1)))
 	{
 		// Handle local user names starting or ending with "@" like "@example" or "example@" and make sure they aren't treated as remote
+		atRange.location = NSNotFound;
+	}
+
+	if ((atRange.location != NSNotFound) && (_forceIsRemote != nil) && !_forceIsRemote.boolValue)
+	{
+		// Handle local user names containing an "@", like "guest@domain.com" correctly if explicit information for the remote status is available
 		atRange.location = NSNotFound;
 	}
 
@@ -89,7 +106,7 @@
 	{
 		_avatar = [UIImage imageWithData:self.avatarData];
 	}
-	
+
 	return (_avatar);
 }
 
@@ -142,7 +159,7 @@
 		self.emailAddress = [decoder decodeObjectOfClass:[NSString class] forKey:@"emailAddress"];
 		self.avatarData = [decoder decodeObjectOfClass:[NSData class] forKey:@"avatarData"];
 	}
-	
+
 	return (self);
 }
 

--- a/ownCloudSDKTests/SharingTests.m
+++ b/ownCloudSDKTests/SharingTests.m
@@ -1124,4 +1124,39 @@
 	[self waitForExpectationsWithTimeout:60 handler:nil];
 }
 
+- (void)testUserIDParsing
+{
+	OCUser *user;
+
+	user = [OCUser userWithUserName:@"admin" displayName:@"admin"];
+	XCTAssert(!user.isRemote);
+	XCTAssert([user.userName isEqual:@"admin"]);
+	XCTAssert(user.remoteUserName == nil);
+	XCTAssert(user.remoteHost == nil);
+
+	user = [OCUser userWithUserName:@"admin@localhost" displayName:@"admin" isRemote:NO];
+	XCTAssert(!user.isRemote);
+	XCTAssert([user.userName isEqual:@"admin@localhost"]);
+	XCTAssert(user.remoteUserName == nil);
+	XCTAssert(user.remoteHost == nil);
+
+	user = [OCUser userWithUserName:@"admin@localhost" displayName:@"admin" isRemote:YES];
+	XCTAssert(user.isRemote);
+	XCTAssert([user.userName isEqual:@"admin@localhost"]);
+	XCTAssert([user.remoteUserName isEqual:@"admin"]);
+	XCTAssert([user.remoteHost isEqual:@"localhost"]);
+
+	user = [OCUser userWithUserName:@"admin@localhost@remote" displayName:@"admin"];
+	XCTAssert(user.isRemote);
+	XCTAssert([user.userName isEqual:@"admin@localhost@remote"]);
+	XCTAssert([user.remoteUserName isEqual:@"admin@localhost"]);
+	XCTAssert([user.remoteHost isEqual:@"remote"]);
+
+	user = [OCUser userWithUserName:@"admin@localhost@remote" displayName:@"admin" isRemote:NO];
+	XCTAssert(!user.isRemote);
+	XCTAssert([user.userName isEqual:@"admin@localhost@remote"]);
+	XCTAssert(user.remoteUserName == nil);
+	XCTAssert(user.remoteHost == nil);
+}
+
 @end


### PR DESCRIPTION
## Description
- OCUser: added new initializer to allow explicitly specifying if a user is a remote or local user, to allow local user names formatted like federated ones (f.ex. user@localhost)
- OCConnection+Recipients uses the new OCUser-initializer in combination with the API's shareType info
- Moved manual creations of OCUser to use the initializers in other places
- Added unit test to cover the new OCUser capabilities

## Related Issue
https://github.com/owncloud/ios-app/pull/453

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
