### PR TITLE
[fix/auth] Auth error verbosity improvements

### DIFF
--- a/ownCloudSDK/Errors/NSError+OCDAVError.h
+++ b/ownCloudSDK/Errors/NSError+OCDAVError.h
@@ -34,10 +34,10 @@ typedef NS_ENUM(NSInteger, OCDAVError)
 @interface NSError (OCDAVError) <OCXMLObjectCreation>
 
 #pragma mark - Convenience accessors
-- (BOOL)isDAVException; //!< Returns YES if the error represents a DAV exception
-- (OCDAVError)davError; //!< Returns the OCDAVError code. Returns OCDAVErrorNone if this error doesn't represent a OCDAVError
-- (nullable OCDAVExceptionName)davExceptionName;
-- (nullable NSString *)davExceptionMessage;
+@property(readonly,nonatomic) BOOL isDAVException; //!< Returns YES if the error represents a DAV exception
+@property(readonly,nonatomic) OCDAVError davError; //!< Returns the OCDAVError code. Returns OCDAVErrorNone if this error doesn't represent a OCDAVError
+@property(readonly,strong,nullable,nonatomic) OCDAVExceptionName davExceptionName;
+@property(readonly,strong,nullable,nonatomic) NSString *davExceptionMessage;
 
 @end
 


### PR DESCRIPTION
## Description
- Provide underlying error for 401 UNAUHTORIZED responses, if the body of the response is a DAV XML error
- Turn NSError+OCDAVError methods into properties for a Swiftier interface

## Related Issue
https://github.com/owncloud/enterprise/issues/3406

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)