### PR TITLE
Added wipe function allowing deleting all keychain items

### DIFF
--- a/ownCloudSDK/Security/OCKeychain.h
+++ b/ownCloudSDK/Security/OCKeychain.h
@@ -32,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSData *)readDataFromKeychainItemForAccount:(NSString *)account path:(NSString *)path;
 - (nullable NSError *)writeData:(nullable NSData *)data toKeychainItemForAccount:(NSString *)account path:(NSString *)path;
 - (nullable NSError *)removeKeychainItemForAccount:(NSString *)account path:(NSString *)path;
+- (BOOL)wipe;
 
 #pragma mark - Object interface
 - (nullable id)readObjectFromKeychainItemForAccount:(NSString *)account path:(NSString *)path allowedClasses:(NSSet<Class> *)allowedClasses rootClass:(Class)rootClass error:(NSError * _Nullable * _Nullable)outError;

--- a/ownCloudSDK/Security/OCKeychain.m
+++ b/ownCloudSDK/Security/OCKeychain.m
@@ -172,6 +172,21 @@
 	return ([self writeData:nil toKeychainItemForAccount:account path:path]);
 }
 
+- (BOOL)wipe
+{
+	OSStatus status = errSecSuccess;
+	NSMutableDictionary <NSString *, id> *queryDict;
+	
+	if ((queryDict = [self _queryType:NULL dictForAccount:nil path:nil]) != nil)
+	{
+		status = SecItemDelete((CFDictionaryRef)queryDict);
+
+		OCTLogDebug(@[@"Delete"], @"Delete all items, status=%d", status);
+	}
+
+	return (status == errSecSuccess);
+}
+
 - (id)readObjectFromKeychainItemForAccount:(NSString *)account path:(NSString *)path allowedClasses:(NSSet<Class> *)allowedClasses rootClass:(Class)rootClass error:(NSError **)outError
 {
 	NSData *data;


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.
-->

## Description
Added  a method to `OCKeychain` allowing to wipe all items stored there

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
iOS does retain keychain even if the app is deleted, so we need a method of resetting it upon reinstall

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

