### PR TITLE
[milestone/11.7.2] Version 11.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 11.8 version
+- Infinite PROPFIND: add support for dav > propfind > depth_infinity capability
+- OCLocale: modular localization system replacing direct system localization calls, allowing overrides via MDM and Branding.plist, adding variable support
+- OCCore+FileProvider: add handling for edge case when the database is not available or not open, preventing a hang
+- OCCore+ItemList: implement coordinated scan for changes
+	- synchronizes scans for changes across processes
+	- prioritizes scans, giving the app highest and the fileprovider second highest priority
+	- consolidate related log messages under ScanChanges tag (including PollForChanges and UpdateScan)
+- OCLock: add support for trying to acquire a lock and immediately returning with the result, with a new OCErrorLockInvalidated error code in case the lock couldn't be acquired
+- OCSQLiteDB: disable statement caching in minimum memory configuration
+- Browser Session Class: add AWBrowser to simplify configuration for AirWatch browser
+- Class Settings: metadata type corrections; no longer output "computed: '<null>'" entries for class settings in the LogIntro if it is the only entry for that MDM parameter
+
 ## 11.7.1 version
 
 - support for streaming, infinite PROPFIND to prepopulate accounts and speed up initial discovery

--- a/ownCloudSDK.xcodeproj/project.pbxproj
+++ b/ownCloudSDK.xcodeproj/project.pbxproj
@@ -584,6 +584,8 @@
 		DCE26621211348B00001FB2C /* OCCore+CommandLocalImport.m in Sources */ = {isa = PBXBuildFile; fileRef = DCE2661F211348B00001FB2C /* OCCore+CommandLocalImport.m */; };
 		DCE370942099D18100114981 /* OCDatabaseConsistentOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = DCE370922099D18100114981 /* OCDatabaseConsistentOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DCE370952099D18100114981 /* OCDatabaseConsistentOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = DCE370932099D18100114981 /* OCDatabaseConsistentOperation.m */; };
+		DCE3D4E42701C40B0074C254 /* OCCoreUpdateScheduleRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = DCE3D4E22701C40B0074C254 /* OCCoreUpdateScheduleRecord.h */; };
+		DCE3D4E52701C40B0074C254 /* OCCoreUpdateScheduleRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = DCE3D4E32701C40B0074C254 /* OCCoreUpdateScheduleRecord.m */; };
 		DCE451A52459AD3F0074363F /* OCTUSJob.h in Headers */ = {isa = PBXBuildFile; fileRef = DCE451A32459AD3F0074363F /* OCTUSJob.h */; };
 		DCE451A62459AD3F0074363F /* OCTUSJob.m in Sources */ = {isa = PBXBuildFile; fileRef = DCE451A42459AD3F0074363F /* OCTUSJob.m */; };
 		DCE48DD8220E1C7B00839E97 /* OCHTTPPipelineTaskCache.h in Headers */ = {isa = PBXBuildFile; fileRef = DCE48DD6220E1C7A00839E97 /* OCHTTPPipelineTaskCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1385,6 +1387,8 @@
 		DCE2661F211348B00001FB2C /* OCCore+CommandLocalImport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "OCCore+CommandLocalImport.m"; sourceTree = "<group>"; };
 		DCE370922099D18100114981 /* OCDatabaseConsistentOperation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OCDatabaseConsistentOperation.h; sourceTree = "<group>"; };
 		DCE370932099D18100114981 /* OCDatabaseConsistentOperation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OCDatabaseConsistentOperation.m; sourceTree = "<group>"; };
+		DCE3D4E22701C40B0074C254 /* OCCoreUpdateScheduleRecord.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OCCoreUpdateScheduleRecord.h; sourceTree = "<group>"; };
+		DCE3D4E32701C40B0074C254 /* OCCoreUpdateScheduleRecord.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OCCoreUpdateScheduleRecord.m; sourceTree = "<group>"; };
 		DCE451A32459AD3F0074363F /* OCTUSJob.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OCTUSJob.h; sourceTree = "<group>"; };
 		DCE451A42459AD3F0074363F /* OCTUSJob.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OCTUSJob.m; sourceTree = "<group>"; };
 		DCE48DD6220E1C7A00839E97 /* OCHTTPPipelineTaskCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OCHTTPPipelineTaskCache.h; sourceTree = "<group>"; };
@@ -2788,6 +2792,8 @@
 				DC3FE4B8229BD424002E009C /* OCCoreDirectoryUpdateJob.h */,
 				DCC3701224D4D134008B0DEB /* OCScanJobActivity.m */,
 				DCC3701124D4D134008B0DEB /* OCScanJobActivity.h */,
+				DCE3D4E32701C40B0074C254 /* OCCoreUpdateScheduleRecord.m */,
+				DCE3D4E22701C40B0074C254 /* OCCoreUpdateScheduleRecord.h */,
 			);
 			path = ItemList;
 			sourceTree = "<group>";
@@ -3422,6 +3428,7 @@
 				DCC8F9EA2028557100EB6701 /* OCDatabase.h in Headers */,
 				DC76500C2404703A00201812 /* OCWaitConditionMetaDataRefresh.h in Headers */,
 				DC4B11FE220996480062BCDD /* OCProgress.h in Headers */,
+				DCE3D4E42701C40B0074C254 /* OCCoreUpdateScheduleRecord.h in Headers */,
 				DC02835B209098D7005B6334 /* OCImage.h in Headers */,
 				DC3422822180765900705508 /* OCCore+ItemUpdates.h in Headers */,
 				DCD038A02542CA4500F97534 /* NSString+OCClassSettings.h in Headers */,
@@ -3878,6 +3885,7 @@
 				DCC8FA26202B259D00EB6701 /* OCSyncRecord.m in Sources */,
 				DC6ABF752536058A00689C7B /* OCHostSimulatorResponse.m in Sources */,
 				DCDD9B2C22312ED80052A001 /* OCRateLimiter.m in Sources */,
+				DCE3D4E52701C40B0074C254 /* OCCoreUpdateScheduleRecord.m in Sources */,
 				DC4E0A5920927048007EB05F /* OCItemVersionIdentifier.m in Sources */,
 				DCEEB2EA2046BC2600189B9A /* OCHTTPStatus.m in Sources */,
 				DC62FD63211B11FD0034B628 /* OCItem+OCThumbnail.m in Sources */,

--- a/ownCloudSDK.xcodeproj/project.pbxproj
+++ b/ownCloudSDK.xcodeproj/project.pbxproj
@@ -356,6 +356,8 @@
 		DC7650092403DF5000201812 /* NSError+OCNetworkFailure.m in Sources */ = {isa = PBXBuildFile; fileRef = DC7650072403DF5000201812 /* NSError+OCNetworkFailure.m */; };
 		DC76500C2404703A00201812 /* OCWaitConditionMetaDataRefresh.h in Headers */ = {isa = PBXBuildFile; fileRef = DC76500A2404703A00201812 /* OCWaitConditionMetaDataRefresh.h */; };
 		DC76500D2404703A00201812 /* OCWaitConditionMetaDataRefresh.m in Sources */ = {isa = PBXBuildFile; fileRef = DC76500B2404703A00201812 /* OCWaitConditionMetaDataRefresh.m */; };
+		DC772E9126FC90E2002C0015 /* OCAuthenticationBrowserSessionAWBrowser.h in Headers */ = {isa = PBXBuildFile; fileRef = DC772E8F26FC90E2002C0015 /* OCAuthenticationBrowserSessionAWBrowser.h */; };
+		DC772E9226FC90E2002C0015 /* OCAuthenticationBrowserSessionAWBrowser.m in Sources */ = {isa = PBXBuildFile; fileRef = DC772E9026FC90E2002C0015 /* OCAuthenticationBrowserSessionAWBrowser.m */; };
 		DC79E1A42058725700189B9A /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = DC79E1A62058725700189B9A /* Localizable.strings */; };
 		DC79E1A92058747100189B9A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DC79E1A72058747000189B9A /* LaunchScreen.storyboard */; };
 		DC79E1AA2058747100189B9A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DC79E1A82058747100189B9A /* Main.storyboard */; };
@@ -1143,6 +1145,8 @@
 		DC7650072403DF5000201812 /* NSError+OCNetworkFailure.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSError+OCNetworkFailure.m"; sourceTree = "<group>"; };
 		DC76500A2404703A00201812 /* OCWaitConditionMetaDataRefresh.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OCWaitConditionMetaDataRefresh.h; sourceTree = "<group>"; };
 		DC76500B2404703A00201812 /* OCWaitConditionMetaDataRefresh.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OCWaitConditionMetaDataRefresh.m; sourceTree = "<group>"; };
+		DC772E8F26FC90E2002C0015 /* OCAuthenticationBrowserSessionAWBrowser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OCAuthenticationBrowserSessionAWBrowser.h; sourceTree = "<group>"; };
+		DC772E9026FC90E2002C0015 /* OCAuthenticationBrowserSessionAWBrowser.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OCAuthenticationBrowserSessionAWBrowser.m; sourceTree = "<group>"; };
 		DC79E1A52058725700189B9A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DC79E1A72058747000189B9A /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		DC79E1A82058747100189B9A /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
@@ -2324,6 +2328,15 @@
 			path = Sources;
 			sourceTree = "<group>";
 		};
+		DC772E8E26FC908D002C0015 /* AWBrowser */ = {
+			isa = PBXGroup;
+			children = (
+				DC772E9026FC90E2002C0015 /* OCAuthenticationBrowserSessionAWBrowser.m */,
+				DC772E8F26FC90E2002C0015 /* OCAuthenticationBrowserSessionAWBrowser.h */,
+			);
+			path = AWBrowser;
+			sourceTree = "<group>";
+		};
 		DC79E1A2205871B800189B9A /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -2663,6 +2676,7 @@
 				DC8EB2FD23951AAB009148F9 /* OCAuthenticationBrowserSession.m */,
 				DC8EB2FC23951AAB009148F9 /* OCAuthenticationBrowserSession.h */,
 				DC6CC30426428DA40040ECAC /* Custom Scheme */,
+				DC772E8E26FC908D002C0015 /* AWBrowser */,
 				DC6CC30C2642A0570040ECAC /* MIBrowser */,
 				DC8EB30123952049009148F9 /* UIWebView */,
 			);
@@ -3367,6 +3381,7 @@
 				DC708CE4214135E200FE43CA /* OCSyncActionDownload.h in Headers */,
 				DC188997218B09CC00CFB3F9 /* OCLogFileSource.h in Headers */,
 				DCDD9B14222986D50052A001 /* OCShare+OCXMLObjectCreation.h in Headers */,
+				DC772E9126FC90E2002C0015 /* OCAuthenticationBrowserSessionAWBrowser.h in Headers */,
 				DCE451A52459AD3F0074363F /* OCTUSJob.h in Headers */,
 				DCDD9B2B22312ED80052A001 /* OCRateLimiter.h in Headers */,
 				DC6ABF7925365CB100689C7B /* OCHostSimulator+BuiltIn.h in Headers */,
@@ -3802,6 +3817,7 @@
 				DCD038A12542CA4500F97534 /* NSString+OCClassSettings.m in Sources */,
 				DC68057E212EB438006C3B1F /* OCExtensionMatch.m in Sources */,
 				DC9D22EB25A8754200CF5675 /* OCHTTPRequest+JSON.m in Sources */,
+				DC772E9226FC90E2002C0015 /* OCAuthenticationBrowserSessionAWBrowser.m in Sources */,
 				DC302AEF221EAC55003218C6 /* OCProxyProgress.m in Sources */,
 				DC4B1172220830F20062BCDD /* OCHTTPPipelineBackend.m in Sources */,
 				DCE26621211348B00001FB2C /* OCCore+CommandLocalImport.m in Sources */,

--- a/ownCloudSDK.xcodeproj/project.pbxproj
+++ b/ownCloudSDK.xcodeproj/project.pbxproj
@@ -26,6 +26,14 @@
 		DC0364FB20AAD75700F62732 /* OCCore+SyncEngine.h in Headers */ = {isa = PBXBuildFile; fileRef = DC0364F920AAD75700F62732 /* OCCore+SyncEngine.h */; };
 		DC0364FC20AAD75700F62732 /* OCCore+SyncEngine.m in Sources */ = {isa = PBXBuildFile; fileRef = DC0364FA20AAD75700F62732 /* OCCore+SyncEngine.m */; };
 		DC03650620AAEFBD00F62732 /* DatabaseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DC03650520AAEFBD00F62732 /* DatabaseTests.m */; };
+		DC0376DE271A33B900151E8C /* OCLocale.h in Headers */ = {isa = PBXBuildFile; fileRef = DC0376DC271A33B900151E8C /* OCLocale.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DC0376DF271A33B900151E8C /* OCLocale.m in Sources */ = {isa = PBXBuildFile; fileRef = DC0376DD271A33B900151E8C /* OCLocale.m */; };
+		DC0376EA271B1A4900151E8C /* OCLocaleFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = DC0376E8271B1A4900151E8C /* OCLocaleFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DC0376EB271B1A4900151E8C /* OCLocaleFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = DC0376E9271B1A4900151E8C /* OCLocaleFilter.m */; };
+		DC0376EE271B1C8500151E8C /* OCLocaleFilterClassSettings.h in Headers */ = {isa = PBXBuildFile; fileRef = DC0376EC271B1C8500151E8C /* OCLocaleFilterClassSettings.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DC0376EF271B1C8500151E8C /* OCLocaleFilterClassSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = DC0376ED271B1C8500151E8C /* OCLocaleFilterClassSettings.m */; };
+		DC0376F2271B1D4600151E8C /* OCLocaleFilterVariables.h in Headers */ = {isa = PBXBuildFile; fileRef = DC0376F0271B1D4600151E8C /* OCLocaleFilterVariables.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DC0376F3271B1D4600151E8C /* OCLocaleFilterVariables.m in Sources */ = {isa = PBXBuildFile; fileRef = DC0376F1271B1D4600151E8C /* OCLocaleFilterVariables.m */; };
 		DC03AC472229598E006901DC /* OCConnection+Sharing.m in Sources */ = {isa = PBXBuildFile; fileRef = DC03AC452229598E006901DC /* OCConnection+Sharing.m */; };
 		DC03AC4922295AA6006901DC /* SharingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DC03AC4822295AA6006901DC /* SharingTests.m */; };
 		DC04A4942330290A006285AC /* OCCoreProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = DC04A4922330290A006285AC /* OCCoreProxy.h */; };
@@ -819,6 +827,14 @@
 		DC0364F920AAD75700F62732 /* OCCore+SyncEngine.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OCCore+SyncEngine.h"; sourceTree = "<group>"; };
 		DC0364FA20AAD75700F62732 /* OCCore+SyncEngine.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "OCCore+SyncEngine.m"; sourceTree = "<group>"; };
 		DC03650520AAEFBD00F62732 /* DatabaseTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DatabaseTests.m; sourceTree = "<group>"; };
+		DC0376DC271A33B900151E8C /* OCLocale.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OCLocale.h; sourceTree = "<group>"; };
+		DC0376DD271A33B900151E8C /* OCLocale.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OCLocale.m; sourceTree = "<group>"; };
+		DC0376E8271B1A4900151E8C /* OCLocaleFilter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OCLocaleFilter.h; sourceTree = "<group>"; };
+		DC0376E9271B1A4900151E8C /* OCLocaleFilter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OCLocaleFilter.m; sourceTree = "<group>"; };
+		DC0376EC271B1C8500151E8C /* OCLocaleFilterClassSettings.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OCLocaleFilterClassSettings.h; sourceTree = "<group>"; };
+		DC0376ED271B1C8500151E8C /* OCLocaleFilterClassSettings.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OCLocaleFilterClassSettings.m; sourceTree = "<group>"; };
+		DC0376F0271B1D4600151E8C /* OCLocaleFilterVariables.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OCLocaleFilterVariables.h; sourceTree = "<group>"; };
+		DC0376F1271B1D4600151E8C /* OCLocaleFilterVariables.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OCLocaleFilterVariables.m; sourceTree = "<group>"; };
 		DC03AC452229598E006901DC /* OCConnection+Sharing.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "OCConnection+Sharing.m"; sourceTree = "<group>"; };
 		DC03AC4822295AA6006901DC /* SharingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SharingTests.m; sourceTree = "<group>"; };
 		DC04A4922330290A006285AC /* OCCoreProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OCCoreProxy.h; sourceTree = "<group>"; };
@@ -1525,6 +1541,21 @@
 				DC62FD60211B11FD0034B628 /* OCItem+OCThumbnail.h */,
 			);
 			path = Images;
+			sourceTree = "<group>";
+		};
+		DC0376DB271A334C00151E8C /* Locale */ = {
+			isa = PBXGroup;
+			children = (
+				DC0376DD271A33B900151E8C /* OCLocale.m */,
+				DC0376DC271A33B900151E8C /* OCLocale.h */,
+				DC0376E9271B1A4900151E8C /* OCLocaleFilter.m */,
+				DC0376E8271B1A4900151E8C /* OCLocaleFilter.h */,
+				DC0376ED271B1C8500151E8C /* OCLocaleFilterClassSettings.m */,
+				DC0376EC271B1C8500151E8C /* OCLocaleFilterClassSettings.h */,
+				DC0376F1271B1D4600151E8C /* OCLocaleFilterVariables.m */,
+				DC0376F0271B1D4600151E8C /* OCLocaleFilterVariables.h */,
+			);
+			path = Locale;
 			sourceTree = "<group>";
 		};
 		DC07C28B21244F9F00B815A4 /* Extensions */ = {
@@ -2930,6 +2961,7 @@
 				DC07C28B21244F9F00B815A4 /* Extensions */,
 				DC855715204FEB9800189B9A /* Categories */,
 				DC855716204FEBAA00189B9A /* XML */,
+				DC0376DB271A334C00151E8C /* Locale */,
 				DC855717204FEBC000189B9A /* Logging */,
 				DCF1C6652631BF80004D8B0F /* Measurement */,
 				DC446C81206B8D9400189B9A /* External */,
@@ -3184,6 +3216,7 @@
 				DCDA307121412A0100DB61A9 /* OCSyncAction.h in Headers */,
 				DCA91F2F21A0BDE400AEDFB4 /* OCSyncAction+FileProvider.h in Headers */,
 				DCD8439A25E1BEE5008D9BBA /* NSDictionary+OCExpand.h in Headers */,
+				DC0376DE271A33B900151E8C /* OCLocale.h in Headers */,
 				DCFF1AB021655C8800ABE40A /* OCItem+OCFileURLMetadata.h in Headers */,
 				DC22669A22817DC600FB29EE /* OCVault+Internal.h in Headers */,
 				DCC8F9BC202852A200EB6701 /* ownCloudSDK.h in Headers */,
@@ -3223,6 +3256,7 @@
 				DCD7AA442580E5A5000CD155 /* NSURLSessionTask+Debug.h in Headers */,
 				DC8EB2FE23951AAB009148F9 /* OCAuthenticationBrowserSession.h in Headers */,
 				DCEEB2F5204802CF00189B9A /* OCIssue.h in Headers */,
+				DC0376EE271B1C8500151E8C /* OCLocaleFilterClassSettings.h in Headers */,
 				DC35969A2240EC0A00C4D6E6 /* OCQueryCondition+Item.h in Headers */,
 				DC4B1171220830F20062BCDD /* OCHTTPPipelineBackend.h in Headers */,
 				DC19BFD221CA6C15007C20D1 /* OCSyncIssueChoice.h in Headers */,
@@ -3305,6 +3339,7 @@
 				DC19BFE921CBACB0007C20D1 /* OCProcessSession.h in Headers */,
 				DCDCA61C245093E800AFA158 /* NSURL+OCPrivateLink.h in Headers */,
 				DC7E0A6F2036F28B006111FA /* OCKeychain.h in Headers */,
+				DC0376EA271B1A4900151E8C /* OCLocaleFilter.h in Headers */,
 				DCC8FA122029D5EC00EB6701 /* OCTypes.h in Headers */,
 				DC114A9422A7A87C00CBD597 /* NSData+OCRandom.h in Headers */,
 				DC114A9822A7AA2E00CBD597 /* NSString+OCRandom.h in Headers */,
@@ -3342,6 +3377,7 @@
 				DC66C6B420540DBD00189B9A /* NSDate+OCDateParser.h in Headers */,
 				DCA35D4D24CF685B00DBE2B0 /* OCDiagnosticNode.h in Headers */,
 				DCB0A45F21B828F400FAC4E9 /* OCCore+ConnectionStatus.h in Headers */,
+				DC0376F2271B1D4600151E8C /* OCLocaleFilterVariables.h in Headers */,
 				DC45ABAE231018250065669D /* OCKeyValueRecord.h in Headers */,
 				DC5D9E6824963DED00BFFE8E /* OCMessageChoice.h in Headers */,
 				DC51FD89247562C20069AB79 /* OCCellularManager.h in Headers */,
@@ -3806,6 +3842,7 @@
 				DCF95AEB25666FBB00806D2A /* OCClassSetting.m in Sources */,
 				DC8EB30523952085009148F9 /* OCAuthenticationBrowserSessionUIWebView.m in Sources */,
 				DCE2661D2113323C0001FB2C /* OCCore+CommandDownload.m in Sources */,
+				DC0376EB271B1A4900151E8C /* OCLocaleFilter.m in Sources */,
 				DCB0A46D21B9355C00FAC4E9 /* OCCoreServerStatusSignalProvider.m in Sources */,
 				DCEEB2F22047094500189B9A /* NSData+OCHash.m in Sources */,
 				DCDD9B1D22298D050052A001 /* OCGroup.m in Sources */,
@@ -3885,6 +3922,7 @@
 				DCC8FA26202B259D00EB6701 /* OCSyncRecord.m in Sources */,
 				DC6ABF752536058A00689C7B /* OCHostSimulatorResponse.m in Sources */,
 				DCDD9B2C22312ED80052A001 /* OCRateLimiter.m in Sources */,
+				DC0376DF271A33B900151E8C /* OCLocale.m in Sources */,
 				DCE3D4E52701C40B0074C254 /* OCCoreUpdateScheduleRecord.m in Sources */,
 				DC4E0A5920927048007EB05F /* OCItemVersionIdentifier.m in Sources */,
 				DCEEB2EA2046BC2600189B9A /* OCHTTPStatus.m in Sources */,
@@ -3931,6 +3969,7 @@
 				DC2F66A12603FCF6001BFDB6 /* OCCancelAction.m in Sources */,
 				DC6DEEBA24C5C82400E3772E /* OCHTTPPolicyBookmark.m in Sources */,
 				DCEE0B7025E697AF006534B5 /* OCCoreManager+ItemResolution.m in Sources */,
+				DC0376EF271B1C8500151E8C /* OCLocaleFilterClassSettings.m in Sources */,
 				DC1889812189EC2600CFB3F9 /* OCLogWriter.m in Sources */,
 				DCADC0492072CDEA00DB8E83 /* OCCoreItemList.m in Sources */,
 				DCDBEE392049EF3C00189B9A /* NSURL+OCURLNormalization.m in Sources */,
@@ -3946,6 +3985,7 @@
 				4C7295E8228DAD6200FA4E68 /* OCLogFileRecord.m in Sources */,
 				DCA91F3021A0BDE400AEDFB4 /* OCSyncAction+FileProvider.m in Sources */,
 				DCADC0532072DE6600DB8E83 /* OCSQLiteMigration.m in Sources */,
+				DC0376F3271B1D4600151E8C /* OCLocaleFilterVariables.m in Sources */,
 				DC545E7B203F7DD0006111FA /* OCUser.m in Sources */,
 				DC576ECB226484F50087316D /* OCBackgroundTask.m in Sources */,
 				DC2565F22260BE3700828AA5 /* OCCertificate+PrivacyLogging.m in Sources */,

--- a/ownCloudSDK/Authentication/Browser Session/AWBrowser/OCAuthenticationBrowserSessionAWBrowser.h
+++ b/ownCloudSDK/Authentication/Browser Session/AWBrowser/OCAuthenticationBrowserSessionAWBrowser.h
@@ -1,0 +1,27 @@
+//
+//  OCAuthenticationBrowserSessionAWBrowser.h
+//  ownCloudSDK
+//
+//  Created by Felix Schwarz on 23.09.21.
+//  Copyright © 2021 ownCloud GmbH. All rights reserved.
+//
+
+/*
+ * Copyright (C) 2021, ownCloud GmbH.
+ *
+ * This code is covered by the GNU Public License Version 3.
+ *
+ * For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+ * You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+ *
+ */
+
+#import <ownCloudSDK/ownCloudSDK.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OCAuthenticationBrowserSessionAWBrowser : OCAuthenticationBrowserSessionCustomScheme
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ownCloudSDK/Authentication/Browser Session/AWBrowser/OCAuthenticationBrowserSessionAWBrowser.m
+++ b/ownCloudSDK/Authentication/Browser Session/AWBrowser/OCAuthenticationBrowserSessionAWBrowser.m
@@ -1,0 +1,33 @@
+//
+//  OCAuthenticationBrowserSessionAWBrowser.m
+//  ownCloudSDK
+//
+//  Created by Felix Schwarz on 23.09.21.
+//  Copyright © 2021 ownCloud GmbH. All rights reserved.
+//
+
+/*
+ * Copyright (C) 2021, ownCloud GmbH.
+ *
+ * This code is covered by the GNU Public License Version 3.
+ *
+ * For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+ * You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+ *
+ */
+
+#import "OCAuthenticationBrowserSessionAWBrowser.h"
+
+@implementation OCAuthenticationBrowserSessionAWBrowser
+
+- (NSString *)plainCustomScheme
+{
+	return (@"awb");
+}
+
+- (NSString *)secureCustomScheme
+{
+	return (@"awbs");
+}
+
+@end

--- a/ownCloudSDK/Authentication/OCAuthenticationMethod.m
+++ b/ownCloudSDK/Authentication/OCAuthenticationMethod.m
@@ -342,7 +342,8 @@ INCLUDE_IN_CLASS_SETTINGS_SNAPSHOTS(OCAuthenticationMethod)
 				@"operating-system" : @"Use ASWebAuthenticationSession for browser sessions.",
 				@"UIWebView" : @"Use UIWebView for browser sessions. Requires compilation with `OC_FEATURE_AVAILABLE_UIWEBVIEW_BROWSER_SESSION=1` preprocessor flag.",
 				@"CustomScheme" : @"Replace http and https with custom schemes to delegate browser sessions to a different app.",
-				@"MIBrowser" : @"Replace `http` with `mibrowser` and `https` with `mibrowsers` to delegate browser sessions to the MobileIron browser."
+				@"MIBrowser" : @"Replace `http` with `mibrowser` and `https` with `mibrowsers` to delegate browser sessions to the MobileIron browser.",
+				@"AWBrowser" : @"Replace `http` with `awb` and `https` with `awbs` to delegate browser sessions to the AirWatch browser."
 			},
 			OCClassSettingsMetadataKeyCategory	: @"Authentication"
 		},

--- a/ownCloudSDK/Authentication/OCAuthenticationMethodOAuth2.m
+++ b/ownCloudSDK/Authentication/OCAuthenticationMethodOAuth2.m
@@ -626,7 +626,7 @@ OCAuthenticationMethodAutoRegister
 {
 	__weak OCAuthenticationMethodOAuth2 *weakSelf = self;
 
-	OCLockRequest *lockRequest = [[OCLockRequest alloc] initWithResourceIdentifier:[NSString stringWithFormat:@"authentication-data-update:%@", connection.bookmark.uuid] acquiredHandler:^(NSError * _Nullable error, OCLock * _Nullable lock) {
+	OCLockRequest *lockRequest = [[OCLockRequest alloc] initWithResourceIdentifier:[NSString stringWithFormat:@"authentication-data-update:%@", connection.bookmark.uuid.UUIDString] acquiredHandler:^(NSError * _Nullable error, OCLock * _Nullable lock) {
 		// Wait for exclusive lock on authentication data before performing the refresh
 		[weakSelf __refreshTokenForConnection:connection availabilityHandler:^(NSError *error, BOOL authenticationIsAvailable) {
 			// Invoke original availabilityHandler

--- a/ownCloudSDK/Connection/Capabilities/OCCapabilities.h
+++ b/ownCloudSDK/Connection/Capabilities/OCCapabilities.h
@@ -55,6 +55,7 @@ typedef NSNumber* OCCapabilityBool;
 #pragma mark - DAV
 @property(readonly,nullable,nonatomic) NSString *davChunkingVersion;
 @property(readonly,nullable,nonatomic) NSArray<NSString *> *davReports;
+@property(readonly,nullable,nonatomic) OCCapabilityBool davPropfindSupportsDepthInfinity;
 
 #pragma mark - TUS
 @property(readonly,nonatomic) BOOL tusSupported;
@@ -73,7 +74,6 @@ typedef NSNumber* OCCapabilityBool;
 @property(readonly,nullable,nonatomic) NSArray<NSString *> *blacklistedFiles;
 @property(readonly,nullable,nonatomic) OCCapabilityBool supportsUndelete;
 @property(readonly,nullable,nonatomic) OCCapabilityBool supportsVersioning;
-@property(readonly,nullable,nonatomic) OCCapabilityBool supportsInfinitePropfind;
 
 #pragma mark - Sharing
 @property(readonly,nullable,nonatomic) OCCapabilityBool sharingAPIEnabled;

--- a/ownCloudSDK/Connection/Capabilities/OCCapabilities.m
+++ b/ownCloudSDK/Connection/Capabilities/OCCapabilities.m
@@ -60,6 +60,7 @@ static NSInteger _defaultSharingSearchMinLength = 2;
 #pragma mark - DAV
 @dynamic davChunkingVersion;
 @dynamic davReports;
+@dynamic davPropfindSupportsDepthInfinity;
 
 #pragma mark - TUS
 @dynamic tusSupported;
@@ -78,7 +79,6 @@ static NSInteger _defaultSharingSearchMinLength = 2;
 @dynamic blacklistedFiles;
 @dynamic supportsUndelete;
 @dynamic supportsVersioning;
-@dynamic supportsInfinitePropfind;
 
 #pragma mark - Sharing
 @dynamic sharingAPIEnabled;
@@ -245,6 +245,11 @@ static NSInteger _defaultSharingSearchMinLength = 2;
 	return (OCTypedCast(_capabilities[@"dav"][@"reports"], NSArray));
 }
 
+- (OCCapabilityBool)davPropfindSupportsDepthInfinity
+{
+	return (OCTypedCast(_capabilities[@"dav"][@"propfind"][@"depth_infinity"], NSNumber));
+}
+
 #pragma mark - TUS
 - (BOOL)tusSupported
 {
@@ -342,12 +347,6 @@ static NSInteger _defaultSharingSearchMinLength = 2;
 - (OCCapabilityBool)supportsVersioning
 {
 	return (OCTypedCast(_capabilities[@"files"][@"versioning"], NSNumber));
-}
-
-- (OCCapabilityBool)supportsInfinitePropfind
-{
-	// Prepared for future server-side capability
-	return (nil);
 }
 
 #pragma mark - Sharing

--- a/ownCloudSDK/Core/FileProvider/OCCore+FileProvider.m
+++ b/ownCloudSDK/Core/FileProvider/OCCore+FileProvider.m
@@ -30,11 +30,21 @@
 {
 	[self queueBlock:^{
 		OCSyncExec(cacheItemRetrieval, {
-			[self.vault.database retrieveCacheItemForLocalID:localID completionHandler:^(OCDatabase *db, NSError *error, OCSyncAnchor syncAnchor, OCItem *item) {
-				completionHandler(error, syncAnchor, item);
+			OCDatabase *database = self.vault.database;
 
+			if ((database != nil) && database.isOpened)
+			{
+				[self.vault.database retrieveCacheItemForLocalID:localID completionHandler:^(OCDatabase *db, NSError *error, OCSyncAnchor syncAnchor, OCItem *item) {
+					completionHandler(error, syncAnchor, item);
+
+					OCSyncExecDone(cacheItemRetrieval);
+				}];
+			}
+			else
+			{
+				completionHandler(nil, nil, nil);
 				OCSyncExecDone(cacheItemRetrieval);
-			}];
+			}
 		});
 	}];
 }

--- a/ownCloudSDK/Core/ItemList/OCCore+ItemList.h
+++ b/ownCloudSDK/Core/ItemList/OCCore+ItemList.h
@@ -17,6 +17,8 @@
  */
 
 #import "OCCore.h"
+#import "OCLockManager.h"
+#import "OCLockRequest.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -40,6 +42,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)scheduleUpdateScanForPath:(OCPath)path waitForNextQueueCycle:(BOOL)waitForNextQueueCycle;
 - (void)recoverPendingUpdateJobs;
 
+- (void)coordinatedScanForChanges;
+- (void)shutdownCoordinatedScanForChanges;
+
 @end
 
 @interface OCCore (ItemListInternal)
@@ -47,5 +52,8 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 extern OCActivityIdentifier OCActivityIdentifierPendingServerScanJobsSummary; //!< The activity reporting the progress of background checks for updates
+
+extern OCKeyValueStoreKey OCKeyValueStoreKeyCoreUpdateScheduleRecord;
+extern OCLockResourceIdentifier OCLockResourceIdentifierCoreUpdateScan;
 
 NS_ASSUME_NONNULL_END

--- a/ownCloudSDK/Core/ItemList/OCCoreUpdateScheduleRecord.h
+++ b/ownCloudSDK/Core/ItemList/OCCoreUpdateScheduleRecord.h
@@ -1,0 +1,51 @@
+//
+//  OCCoreUpdateScheduleRecord.h
+//  ownCloudSDK
+//
+//  Created by Felix Schwarz on 27.09.21.
+//  Copyright © 2021 ownCloud GmbH. All rights reserved.
+//
+
+/*
+ * Copyright (C) 2021, ownCloud GmbH.
+ *
+ * This code is covered by the GNU Public License Version 3.
+ *
+ * For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+ * You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+#import "OCAppIdentity.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OCCoreUpdateScheduleRecord : NSObject <NSSecureCoding>
+{
+	NSMutableDictionary<OCAppComponentIdentifier, NSDate *> *_lastTimestampByComponents;
+}
+
+@property(class,strong,nonatomic,readonly) NSArray<OCAppComponentIdentifier> *prioritizedComponents;
+
+@property(strong,nullable) NSString *lastCheckComponent;
+@property(strong,nullable) NSDate *lastCheckBegin;
+@property(strong,nullable) NSDate *lastCheckEnd;
+
+@property(assign) NSTimeInterval pollInterval;
+
+@property(readonly,strong,nullable) NSDictionary<OCAppComponentIdentifier, NSDate *> *lastTimestampByComponents;
+
+- (void)beginCheck;
+- (void)endCheck;
+
+- (void)updateComponentTimestamp;
+
+- (nullable NSDate *)nextDateByBeginAndEndDate;
+- (nullable NSDate *)nextDateByPrioritizedComponents:(NSString * _Nullable * _Nullable)outComponent;
+
+//- (nullable NSDate *)nextUpdateAttemptDate; //!< Returns the date at which to re-attempt updating. If updating should be attempted immediately, returns nil.
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ownCloudSDK/Core/ItemList/OCCoreUpdateScheduleRecord.m
+++ b/ownCloudSDK/Core/ItemList/OCCoreUpdateScheduleRecord.m
@@ -1,0 +1,155 @@
+//
+//  OCCoreUpdateScheduleRecord.m
+//  ownCloudSDK
+//
+//  Created by Felix Schwarz on 27.09.21.
+//  Copyright © 2021 ownCloud GmbH. All rights reserved.
+//
+
+/*
+ * Copyright (C) 2021, ownCloud GmbH.
+ *
+ * This code is covered by the GNU Public License Version 3.
+ *
+ * For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+ * You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+ *
+ */
+
+#import "OCCoreUpdateScheduleRecord.h"
+
+@implementation OCCoreUpdateScheduleRecord
+
++ (NSArray<OCAppComponentIdentifier> *)prioritizedComponents
+{
+	return @[
+		OCAppComponentIdentifierApp,
+		OCAppComponentIdentifierFileProviderExtension
+	];
+}
+
+- (void)beginCheck
+{
+	self.lastCheckComponent = OCAppIdentity.sharedAppIdentity.componentIdentifier;
+	self.lastCheckBegin = [NSDate new];
+	self.lastCheckEnd = nil;
+
+	[self updateComponentTimestamp];
+}
+
+- (void)endCheck
+{
+	if ([self.lastCheckComponent isEqual:OCAppIdentity.sharedAppIdentity.componentIdentifier])
+	{
+		self.lastCheckEnd = [NSDate new];
+	}
+
+	[self updateComponentTimestamp];
+}
+
+- (void)updateComponentTimestamp
+{
+	OCAppComponentIdentifier componentID;
+
+	if ((componentID = OCAppIdentity.sharedAppIdentity.componentIdentifier) != nil)
+	{
+		if (_lastTimestampByComponents == nil)
+		{
+			_lastTimestampByComponents = [NSMutableDictionary new];
+		}
+
+		_lastTimestampByComponents[componentID] = [NSDate new];
+	}
+}
+
+- (nullable NSDate *)nextDateByBeginAndEndDate
+{
+	// - check last time the last scan ended or, where not available, began
+	// 	- otherwise schedule considerScan again in $secondsRemainigUntilPollInterval, update $lastComponentAttemptTimestamp
+	// 	- if more than $pollInterval seconds ago, proceed \/
+
+	NSDate *lastScan = (self.lastCheckEnd != nil) ? self.lastCheckEnd : self.lastCheckBegin;
+	NSTimeInterval elapsedTime = -lastScan.timeIntervalSinceNow;
+
+	if ((lastScan!=nil) && (elapsedTime < _pollInterval))
+	{
+		return ([NSDate dateWithTimeIntervalSinceNow:_pollInterval-elapsedTime]);
+	}
+
+	return (nil);
+}
+
+- (nullable NSDate *)nextDateByPrioritizedComponents:(NSString * _Nullable * _Nullable)outComponent
+{
+	// - priority: check the $lastComponentAttemptTimestamp of other components
+	// 	- if a higher-ranking component (using OCAppIdentity.componentIdentifier: app, fileprovider, * (anything else))
+	// 	  saved a timestamp less than ($pollInterval * 2) seconds ago, update own $lastComponentAttemptTimestamp and
+	//	  reschedule considerScan in (($pollInterval * 2) + 2)
+	// 	- otherwhise proceed \/
+
+	OCAppComponentIdentifier currentComponent = OCAppIdentity.sharedAppIdentity.componentIdentifier;
+	NSDate *nextDate = nil;
+
+	for (OCAppComponentIdentifier checkComponent in OCCoreUpdateScheduleRecord.prioritizedComponents)
+	{
+		if ([checkComponent isEqual:currentComponent]) {
+			// Timestamps of the current component and any components with lower priority
+			// should be ignored
+			break;
+		}
+
+		NSDate *componentTimestamp;
+
+		if ((componentTimestamp = _lastTimestampByComponents[checkComponent]) != nil)
+		{
+			NSTimeInterval elapsedTime = -componentTimestamp.timeIntervalSinceNow;
+
+			if (elapsedTime < (_pollInterval * 2.0))
+			{
+				// timestamp less than ($pollInterval * 2) seconds ago => reschedule in (($pollInterval * 2) + 2)
+				nextDate = [NSDate dateWithTimeIntervalSinceNow:((_pollInterval * 2.0) + 2.0)];
+
+				if (outComponent != NULL)
+				{
+					*outComponent = checkComponent;
+				}
+				break;
+			}
+		}
+	}
+
+	return (nextDate);
+}
+
+#pragma mark - Secure Coding
++ (BOOL)supportsSecureCoding
+{
+	return (YES);
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder
+{
+	[coder encodeDouble:_pollInterval forKey:@"pollInterval"];
+
+	[coder encodeObject:_lastCheckBegin forKey:@"lastCheckBegin"];
+	[coder encodeObject:_lastCheckEnd forKey:@"lastCheckEnd"];
+	[coder encodeObject:_lastCheckComponent forKey:@"lastCheckComponent"];
+	[coder encodeObject:_lastTimestampByComponents forKey:@"lastTimestampByComponents"];
+}
+
+- (instancetype)initWithCoder:(NSCoder *)decoder
+{
+	if ((self = [super init]) != nil)
+	{
+		_pollInterval = [decoder decodeDoubleForKey:@"pollInterval"];
+
+		_lastCheckBegin = [decoder decodeObjectOfClass:NSDate.class forKey:@"lastCheckBegin"];
+		_lastCheckEnd = [decoder decodeObjectOfClass:NSDate.class forKey:@"lastCheckEnd"];
+		_lastCheckComponent = [decoder decodeObjectOfClass:NSString.class forKey:@"lastCheckComponent"];
+		_lastTimestampByComponents = [decoder decodeObjectOfClasses:[[NSSet alloc] initWithObjects:NSMutableDictionary.class, NSString.class, NSDate.class, nil] forKey:@"lastTimestampByComponents"];
+	}
+
+	return (self);
+}
+
+@end

--- a/ownCloudSDK/Core/ItemPolicies/Processors/Vacuum/OCItemPolicyProcessorVacuum.m
+++ b/ownCloudSDK/Core/ItemPolicies/Processors/Vacuum/OCItemPolicyProcessorVacuum.m
@@ -32,7 +32,7 @@
 		OCClassSettingsKeyItemPolicyVacuumSyncAnchorTTL : @(OCSyncAnchorTimeToLiveInSeconds)
 	} metadata:@{
 		OCClassSettingsKeyItemPolicyVacuumSyncAnchorTTL : @{
-			OCClassSettingsMetadataKeyType 	      	 : OCClassSettingsMetadataTypeBoolean,
+			OCClassSettingsMetadataKeyType 	      	 : OCClassSettingsMetadataTypeInteger,
 			OCClassSettingsMetadataKeyDescription 	 : @"Number of seconds since the removal of an item after which the metadata entry may be finally removed.",
 			OCClassSettingsMetadataKeyCategory    	 : @"Policies",
 			OCClassSettingsMetadataKeyStatus	 : OCClassSettingsKeyStatusDebugOnly

--- a/ownCloudSDK/Core/OCCore.h
+++ b/ownCloudSDK/Core/OCCore.h
@@ -37,6 +37,8 @@
 #import "OCMessageQueue.h"
 #import "OCScanJobActivity.h"
 #import "OCMeasurement.h"
+#import "OCLock.h"
+#import "OCLockRequest.h"
 
 @class OCCore;
 @class OCItem;
@@ -203,6 +205,9 @@ typedef id<NSObject> OCCoreItemTracking;
 	BOOL _itemListTaskRunning;
 	NSTimeInterval _directoryUpdateStartTime;
 	NSMutableArray<OCCoreItemListFetchUpdatesCompletionHandler> *_fetchUpdatesCompletionHandlers;
+	OCLock *_scanForChangesLock;
+	OCLockRequest *_scanForChangesLockRequest;
+	NSTimeInterval _nextCoordinatedScanRetryTime;
 
 	NSMutableArray <OCItemPolicy *> *_itemPolicies;
 	NSMutableArray <OCItemPolicyProcessor *> *_itemPolicyProcessors;

--- a/ownCloudSDK/Core/OCCore.m
+++ b/ownCloudSDK/Core/OCCore.m
@@ -559,6 +559,10 @@ INCLUDE_IN_CLASS_SETTINGS_SNAPSHOTS(OCCore)
 					// Tear down item policies
 					[weakSelf teardownItemPolicies];
 
+					// Release scan for changes lock
+					OCWTLogDebug(stopTags, @"shutting down coordinated scan for changes");
+					[weakSelf shutdownCoordinatedScanForChanges];
+
 					// Shut down Sync Engine
 					OCWTLogDebug(stopTags, @"shutting down sync engine");
 					[weakSelf shutdownSyncEngine];

--- a/ownCloudSDK/Errors/NSError+OCError.h
+++ b/ownCloudSDK/Errors/NSError+OCError.h
@@ -111,7 +111,9 @@ typedef NS_ENUM(NSUInteger, OCError)
 	OCErrorDatabaseMigrationRequired, //!< Database upgrade required. Please open the app to perform the upgrade.
 	OCErrorHostUpdateRequired, //!< Bookmark created with a newer app version. Please update the app.
 
-	OCErrorAuthorizationCantOpenCustomSchemeURL //!< Can't open authorization URL with custom scheme.
+	OCErrorAuthorizationCantOpenCustomSchemeURL, //!< Can't open authorization URL with custom scheme.
+
+	OCErrorLockInvalidated //!< Lock invalidated.
 };
 
 @class OCIssue;

--- a/ownCloudSDK/Errors/NSError+OCError.m
+++ b/ownCloudSDK/Errors/NSError+OCError.m
@@ -340,6 +340,10 @@ static NSString *OCErrorIssueKey = @"OCErrorIssue";
 				case OCErrorAuthorizationCantOpenCustomSchemeURL:
 					unlocalizedString = @"Can't open authorization URL with custom scheme.";
 				break;
+
+				case OCErrorLockInvalidated:
+					unlocalizedString = @"Lock invalidated.";
+				break;
 			}
 		}
 	}

--- a/ownCloudSDK/Events/OCEvent.m
+++ b/ownCloudSDK/Events/OCEvent.m
@@ -50,6 +50,7 @@
 #import "OCMessageChoice.h"
 #import "OCDAVRawResponse.h"
 #import "OCMessage.h"
+#import "OCCoreUpdateScheduleRecord.h"
 
 @implementation OCEvent
 
@@ -112,6 +113,7 @@
 				OCTUSJobSegment.class,
 				OCMessage.class,
 				OCMessageChoice.class,
+				OCCoreUpdateScheduleRecord.class,
 
 				// Foundation classes
 				NSArray.class,

--- a/ownCloudSDK/Locale/OCLocale.h
+++ b/ownCloudSDK/Locale/OCLocale.h
@@ -32,9 +32,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)localizeString:(NSString *)string bundle:(nullable NSBundle *)bundle table:(nullable NSString *)table options:(nullable OCLocaleOptions)options;
 
 + (NSString *)localizeString:(NSString *)string;
++ (NSString *)localizeString:(NSString *)string options:(nullable OCLocaleOptions)options;
 + (NSString *)localizeString:(NSString *)string table:(NSString *)table;
 + (NSString *)localizeString:(NSString *)string bundleOfClass:(Class)class;
++ (NSString *)localizeString:(NSString *)string bundleOfClass:(Class)class options:(nullable OCLocaleOptions)options;
 + (NSString *)localizeString:(NSString *)string bundleOfClass:(Class)class table:(NSString *)table;
++ (NSString *)localizeString:(NSString *)string bundleOfClass:(Class)class table:(NSString *)table options:(nullable OCLocaleOptions)options;
 
 @end
 

--- a/ownCloudSDK/Locale/OCLocale.h
+++ b/ownCloudSDK/Locale/OCLocale.h
@@ -1,0 +1,41 @@
+//
+//  OCLocale.h
+//  OCLocale
+//
+//  Created by Felix Schwarz on 16.10.21.
+//  Copyright © 2021 ownCloud GmbH. All rights reserved.
+//
+
+/*
+ * Copyright (C) 2021, ownCloud GmbH.
+ *
+ * This code is covered by the GNU Public License Version 3.
+ *
+ * For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+ * You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+#import "OCLocaleFilter.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OCLocale : NSObject
+
+@property(readonly,class,nonatomic) OCLocale *sharedLocale;
+@property(readonly,nonatomic,strong) NSArray<OCLocaleFilter *> *filters;
+
+- (void)addFilter:(OCLocaleFilter *)filter;
+- (void)removeFilter:(OCLocaleFilter *)filter;
+
+- (NSString *)localizeString:(NSString *)string bundle:(nullable NSBundle *)bundle table:(nullable NSString *)table options:(nullable OCLocaleOptions)options;
+
++ (NSString *)localizeString:(NSString *)string;
++ (NSString *)localizeString:(NSString *)string table:(NSString *)table;
++ (NSString *)localizeString:(NSString *)string bundleOfClass:(Class)class;
++ (NSString *)localizeString:(NSString *)string bundleOfClass:(Class)class table:(NSString *)table;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ownCloudSDK/Locale/OCLocale.m
+++ b/ownCloudSDK/Locale/OCLocale.m
@@ -1,0 +1,108 @@
+//
+//  OCLocale.m
+//  OCLocale
+//
+//  Created by Felix Schwarz on 16.10.21.
+//  Copyright © 2021 ownCloud GmbH. All rights reserved.
+//
+
+/*
+ * Copyright (C) 2021, ownCloud GmbH.
+ *
+ * This code is covered by the GNU Public License Version 3.
+ *
+ * For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+ * You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+ *
+ */
+
+#import "OCLocale.h"
+#import "OCLocaleFilter.h"
+#import "OCLocaleFilterClassSettings.h"
+#import "OCLocaleFilterVariables.h"
+
+@interface OCLocale ()
+{
+	NSArray<NSString *> *_preferredLanguages;
+	NSMutableArray<OCLocaleFilter *> *_filters;
+}
+@end
+
+@implementation OCLocale
+
++ (OCLocale *)sharedLocale
+{
+	static dispatch_once_t onceToken;
+	static OCLocale *sharedLocale;
+
+	dispatch_once(&onceToken, ^{
+		sharedLocale = [OCLocale new];
+		[sharedLocale addFilter:OCLocaleFilterClassSettings.shared];
+		[sharedLocale addFilter:OCLocaleFilterVariables.shared];
+	});
+
+	return (sharedLocale);
+}
+
+- (instancetype)init
+{
+	if ((self = [super init]) != nil)
+	{
+		_preferredLanguages = NSLocale.preferredLanguages;
+		_filters = [NSMutableArray new];
+	}
+
+	return (self);
+}
+
+- (void)addFilter:(OCLocaleFilter *)filter
+{
+	[_filters addObject:filter];
+}
+
+- (void)removeFilter:(OCLocaleFilter *)filter
+{
+	[_filters removeObject:filter];
+}
+
++ (NSString *)localizeString:(NSString *)string
+{
+	return ([OCLocale.sharedLocale localizeString:string bundle:nil table:nil options:nil]);
+}
+
++ (NSString *)localizeString:(NSString *)string table:(NSString *)table
+{
+	return ([OCLocale.sharedLocale localizeString:string bundle:nil table:table options:nil]);
+}
+
++ (NSString *)localizeString:(NSString *)string bundleOfClass:(Class)class
+{
+	return ([OCLocale.sharedLocale localizeString:string bundle:[NSBundle bundleForClass:class] table:nil options:nil]);
+}
+
++ (NSString *)localizeString:(NSString *)string bundleOfClass:(Class)class table:(NSString *)table
+{
+	return ([OCLocale.sharedLocale localizeString:string bundle:[NSBundle bundleForClass:class] table:table options:nil]);
+}
+
+- (NSString *)localizeString:(NSString *)string bundle:(NSBundle *)bundle table:(NSString *)table options:(OCLocaleOptions)options
+{
+	NSBundle *localeBundle = bundle;
+	NSString *localizedString = nil;
+
+	if (localeBundle == nil)
+	{
+		localeBundle = NSBundle.mainBundle;
+	}
+
+	localizedString = [localeBundle localizedStringForKey:string value:string table:table];
+
+	for (OCLocaleFilter *filter in _filters)
+	{
+		localizedString = [filter applyToLocalizedString:localizedString withOriginalString:string options:options];
+	}
+
+	return (localizedString);
+}
+
+@end

--- a/ownCloudSDK/Locale/OCLocale.m
+++ b/ownCloudSDK/Locale/OCLocale.m
@@ -70,6 +70,11 @@
 	return ([OCLocale.sharedLocale localizeString:string bundle:nil table:nil options:nil]);
 }
 
++ (NSString *)localizeString:(NSString *)string options:(nullable OCLocaleOptions)options
+{
+	return ([OCLocale.sharedLocale localizeString:string bundle:nil table:nil options:options]);
+}
+
 + (NSString *)localizeString:(NSString *)string table:(NSString *)table
 {
 	return ([OCLocale.sharedLocale localizeString:string bundle:nil table:table options:nil]);
@@ -80,9 +85,19 @@
 	return ([OCLocale.sharedLocale localizeString:string bundle:[NSBundle bundleForClass:class] table:nil options:nil]);
 }
 
++ (NSString *)localizeString:(NSString *)string bundleOfClass:(Class)class options:(nullable OCLocaleOptions)options;
+{
+	return ([OCLocale.sharedLocale localizeString:string bundle:[NSBundle bundleForClass:class] table:nil options:options]);
+}
+
 + (NSString *)localizeString:(NSString *)string bundleOfClass:(Class)class table:(NSString *)table
 {
 	return ([OCLocale.sharedLocale localizeString:string bundle:[NSBundle bundleForClass:class] table:table options:nil]);
+}
+
++ (NSString *)localizeString:(NSString *)string bundleOfClass:(Class)class table:(NSString *)table options:(nullable OCLocaleOptions)options
+{
+	return ([OCLocale.sharedLocale localizeString:string bundle:[NSBundle bundleForClass:class] table:table options:options]);
 }
 
 - (NSString *)localizeString:(NSString *)string bundle:(NSBundle *)bundle table:(NSString *)table options:(OCLocaleOptions)options

--- a/ownCloudSDK/Locale/OCLocaleFilter.h
+++ b/ownCloudSDK/Locale/OCLocaleFilter.h
@@ -1,0 +1,32 @@
+//
+//  OCLocaleFilter.h
+//  OCLocaleFilter
+//
+//  Created by Felix Schwarz on 16.10.21.
+//  Copyright © 2021 ownCloud GmbH. All rights reserved.
+//
+
+/*
+ * Copyright (C) 2021, ownCloud GmbH.
+ *
+ * This code is covered by the GNU Public License Version 3.
+ *
+ * For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+ * You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NSString* OCLocaleOptionKey;
+typedef NSDictionary<OCLocaleOptionKey,id>* OCLocaleOptions;
+
+@interface OCLocaleFilter : NSObject
+
+- (nullable NSString *)applyToLocalizedString:(nullable NSString *)localizedString withOriginalString:(NSString *)originalString options:(nullable OCLocaleOptions)options;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ownCloudSDK/Locale/OCLocaleFilter.m
+++ b/ownCloudSDK/Locale/OCLocaleFilter.m
@@ -1,0 +1,28 @@
+//
+//  OCLocaleFilter.m
+//  OCLocaleFilter
+//
+//  Created by Felix Schwarz on 16.10.21.
+//  Copyright © 2021 ownCloud GmbH. All rights reserved.
+//
+
+/*
+ * Copyright (C) 2021, ownCloud GmbH.
+ *
+ * This code is covered by the GNU Public License Version 3.
+ *
+ * For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+ * You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+ *
+ */
+
+#import "OCLocaleFilter.h"
+
+@implementation OCLocaleFilter
+
+- (nullable NSString *)applyToLocalizedString:(nullable NSString *)localizedString withOriginalString:(NSString *)originalString options:(OCLocaleOptions)options
+{
+	return ((localizedString != nil) ? localizedString : originalString);
+}
+
+@end

--- a/ownCloudSDK/Locale/OCLocaleFilterClassSettings.h
+++ b/ownCloudSDK/Locale/OCLocaleFilterClassSettings.h
@@ -1,0 +1,34 @@
+//
+//  OCLocaleFilterClassSettings.h
+//  OCLocaleFilterClassSettings
+//
+//  Created by Felix Schwarz on 16.10.21.
+//  Copyright © 2021 ownCloud GmbH. All rights reserved.
+//
+
+/*
+ * Copyright (C) 2021, ownCloud GmbH.
+ *
+ * This code is covered by the GNU Public License Version 3.
+ *
+ * For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+ * You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+ *
+ */
+
+#import "OCLocaleFilter.h"
+#import "OCClassSettings.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OCLocaleFilterClassSettings : OCLocaleFilter <OCClassSettingsSupport>
+
+@property(class,readonly,nonatomic,strong) OCLocaleFilterClassSettings *shared;
+
+- (void)pullFromClassSettings;
+
+@end
+
+extern OCClassSettingsKey OCClassSettingsKeyLocaleOverrides;
+
+NS_ASSUME_NONNULL_END

--- a/ownCloudSDK/Locale/OCLocaleFilterClassSettings.m
+++ b/ownCloudSDK/Locale/OCLocaleFilterClassSettings.m
@@ -1,0 +1,109 @@
+//
+//  OCLocaleFilterClassSettings.m
+//  OCLocaleFilterClassSettings
+//
+//  Created by Felix Schwarz on 16.10.21.
+//  Copyright © 2021 ownCloud GmbH. All rights reserved.
+//
+
+/*
+ * Copyright (C) 2021, ownCloud GmbH.
+ *
+ * This code is covered by the GNU Public License Version 3.
+ *
+ * For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+ * You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+ *
+ */
+
+#import "OCLocaleFilterClassSettings.h"
+
+@interface OCLocaleFilterClassSettings ()
+{
+	NSDictionary<NSString *, NSString *> *_overrides;
+}
+@end
+
+@implementation OCLocaleFilterClassSettings
+
+#pragma mark - Class settings
++ (OCClassSettingsIdentifier)classSettingsIdentifier
+{
+	return (@"locale");
+}
+
++ (NSDictionary<OCClassSettingsKey, id> *)defaultSettingsForIdentifier:(OCClassSettingsIdentifier)identifier
+{
+	return (@{
+		OCClassSettingsKeyLocaleOverrides : @{ }
+	});
+}
+
++ (OCClassSettingsMetadataCollection)classSettingsMetadata
+{
+	return (@{
+		OCClassSettingsKeyLocaleOverrides : @{
+			OCClassSettingsMetadataKeyType 		: OCClassSettingsMetadataTypeDictionary,
+			OCClassSettingsMetadataKeyLabel 	: @"Localization Overrides",
+			OCClassSettingsMetadataKeyDescription 	: @"Dictionary with localization overrides where the key is the English string whose localization should be overridden, and the value is a dictionary where the keys are the language codes (f.ex. \"en\", \"de\") and the values the translations to use.",
+			OCClassSettingsMetadataKeyStatus	: OCClassSettingsKeyStatusAdvanced,
+			OCClassSettingsMetadataKeyCategory	: @"Localization"
+		},
+	});
+}
+
+#pragma mark - Shared
++ (OCLocaleFilterClassSettings *)shared
+{
+	static dispatch_once_t onceToken;
+	static OCLocaleFilterClassSettings *sharedInstance = nil;
+
+	dispatch_once(&onceToken, ^{
+		sharedInstance = [OCLocaleFilterClassSettings new];
+		[sharedInstance pullFromClassSettings];
+	});
+
+	return (sharedInstance);
+}
+
+- (void)pullFromClassSettings
+{
+	NSDictionary<NSString *,NSDictionary<NSString *, NSString *> *> *overrides = [self classSettingForOCClassSettingsKey:OCClassSettingsKeyLocaleOverrides];
+	NSMutableDictionary<NSString *, NSString *> *computedOverrides = [NSMutableDictionary new];
+
+	[overrides enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull localizeString, NSDictionary<NSString *,NSString *> * _Nonnull translations, BOOL * _Nonnull stop) {
+		NSString *preferredLanguage;
+		NSString *translation = nil;
+
+		if ((preferredLanguage = [NSBundle preferredLocalizationsFromArray:translations.allKeys].firstObject) != nil) {
+			translation = translations[preferredLanguage];
+		};
+
+		if (translation == nil) {
+			translation = localizeString;
+		}
+
+		computedOverrides[localizeString] = translation;
+	}];
+
+	_overrides = computedOverrides;
+}
+
+- (NSString *)applyToLocalizedString:(NSString *)localizedString withOriginalString:(NSString *)originalString options:(OCLocaleOptions)options
+{
+	if (originalString != nil)
+	{
+		NSString *returnString = nil;
+
+		if ((returnString = _overrides[originalString]) != nil)
+		{
+			return (returnString);
+		}
+	}
+
+	return (localizedString);
+}
+
+@end
+
+OCClassSettingsKey OCClassSettingsKeyLocaleOverrides = @"overrides";

--- a/ownCloudSDK/Locale/OCLocaleFilterVariables.h
+++ b/ownCloudSDK/Locale/OCLocaleFilterVariables.h
@@ -31,4 +31,6 @@ typedef NSString * _Nullable(^OCLocaleFilterVariableSource)(void);
 
 @end
 
+extern OCLocaleOptionKey OCLocaleOptionKeyVariables;
+
 NS_ASSUME_NONNULL_END

--- a/ownCloudSDK/Locale/OCLocaleFilterVariables.h
+++ b/ownCloudSDK/Locale/OCLocaleFilterVariables.h
@@ -1,0 +1,34 @@
+//
+//  OCLocaleFilterVariables.h
+//  OCLocaleFilterVariables
+//
+//  Created by Felix Schwarz on 16.10.21.
+//  Copyright © 2021 ownCloud GmbH. All rights reserved.
+//
+
+/*
+ * Copyright (C) 2021, ownCloud GmbH.
+ *
+ * This code is covered by the GNU Public License Version 3.
+ *
+ * For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+ * You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+ *
+ */
+
+#import "OCLocaleFilter.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NSString * _Nullable(^OCLocaleFilterVariableSource)(void);
+
+@interface OCLocaleFilterVariables : OCLocaleFilter
+
+@property(class,readonly,nonatomic,strong) OCLocaleFilterVariables *shared;
+
+- (void)setVariable:(NSString *)variableName value:(nullable NSString *)value;
+- (void)setVariable:(NSString *)variableName source:(nullable OCLocaleFilterVariableSource)source;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ownCloudSDK/Locale/OCLocaleFilterVariables.m
+++ b/ownCloudSDK/Locale/OCLocaleFilterVariables.m
@@ -1,0 +1,145 @@
+//
+//  OCLocaleFilterVariables.m
+//  OCLocaleFilterVariables
+//
+//  Created by Felix Schwarz on 16.10.21.
+//  Copyright © 2021 ownCloud GmbH. All rights reserved.
+//
+
+/*
+ * Copyright (C) 2021, ownCloud GmbH.
+ *
+ * This code is covered by the GNU Public License Version 3.
+ *
+ * For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+ * You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+ *
+ */
+
+#import <UIKit/UIKit.h>
+
+#import "OCLocaleFilterVariables.h"
+#import "OCAppIdentity.h"
+#import "UIDevice+ModelID.h"
+
+@interface OCLocaleFilterVariables()
+{
+	NSMutableDictionary<NSString *, OCLocaleFilterVariableSource> *_sourcesByVariableName;
+	NSMutableDictionary<NSString *, NSString *> *_valueByVariableName;
+}
+
+@end
+
+@implementation OCLocaleFilterVariables
+
+#pragma mark - Shared
++ (OCLocaleFilterVariables *)shared
+{
+	static dispatch_once_t onceToken;
+	static OCLocaleFilterVariables *sharedInstance = nil;
+
+	dispatch_once(&onceToken, ^{
+		sharedInstance = [OCLocaleFilterVariables new];
+
+		[sharedInstance setVariable:@"app.name" 	value:OCAppIdentity.sharedAppIdentity.appDisplayName];
+		[sharedInstance setVariable:@"app.process" 	value:OCAppIdentity.sharedAppIdentity.appName];
+		[sharedInstance setVariable:@"app.version" 	value:OCAppIdentity.sharedAppIdentity.appVersion];
+		[sharedInstance setVariable:@"app.build" 	value:OCAppIdentity.sharedAppIdentity.appBuildNumber];
+
+		[sharedInstance setVariable:@"device.model" 	value:UIDevice.currentDevice.model];
+		[sharedInstance setVariable:@"device.model-id" 	value:UIDevice.currentDevice.ocModelIdentifier];
+		[sharedInstance setVariable:@"os.name"  	value:UIDevice.currentDevice.systemName];
+		[sharedInstance setVariable:@"os.version"  	value:UIDevice.currentDevice.systemVersion];
+	});
+
+	return (sharedInstance);
+}
+
+- (instancetype)init
+{
+	if ((self = [super init]) != nil)
+	{
+		_sourcesByVariableName = [NSMutableDictionary new];
+	}
+
+	return (self);
+}
+
+- (void)setVariable:(NSString *)variableName value:(NSString *)value
+{
+	variableName = [[NSString alloc] initWithFormat:@"{{%@}}", variableName];
+
+	if ((value != nil) && (_valueByVariableName == nil))
+	{
+		_valueByVariableName = [NSMutableDictionary new];
+	}
+
+	_valueByVariableName[variableName] = value;
+
+	if (_valueByVariableName.count == 0)
+	{
+		_valueByVariableName = nil;
+	}
+}
+
+- (void)setVariable:(NSString *)variableName source:(OCLocaleFilterVariableSource)source
+{
+	variableName = [[NSString alloc] initWithFormat:@"{{%@}}", variableName];
+
+	if ((source != nil) && (_sourcesByVariableName == nil))
+	{
+		_sourcesByVariableName = [NSMutableDictionary new];
+	}
+
+	_sourcesByVariableName[variableName] = [source copy];
+
+	if (_sourcesByVariableName.count == 0)
+	{
+		_sourcesByVariableName = nil;
+	}
+}
+
+- (NSString *)applyToLocalizedString:(NSString *)localizedString withOriginalString:(NSString *)originalString options:(OCLocaleOptions)options
+{
+	if (_valueByVariableName != nil)
+	{
+		for (NSString *variableName in _valueByVariableName)
+		{
+			localizedString = [localizedString stringByReplacingOccurrencesOfString:variableName withString:_valueByVariableName[variableName]];
+		}
+	}
+
+	if (_sourcesByVariableName != nil)
+	{
+		for (NSString *variableName in _valueByVariableName)
+		{
+			NSRange range;
+
+			do {
+				range = [localizedString rangeOfString:variableName];
+
+				if (range.location != NSNotFound)
+				{
+					OCLocaleFilterVariableSource source = _sourcesByVariableName[variableName];
+					NSString *computedReplacement;
+
+					if ((computedReplacement = source()) != nil)
+					{
+						localizedString = [localizedString stringByReplacingCharactersInRange:range withString:computedReplacement];
+					}
+					else
+					{
+						// Avoid infinite while-loop
+						break;
+					}
+				}
+			} while(range.location != NSNotFound);
+
+			localizedString = [localizedString stringByReplacingOccurrencesOfString:variableName withString:_valueByVariableName[variableName]];
+		}
+	}
+
+	return (localizedString);
+}
+
+@end

--- a/ownCloudSDK/Locale/OCLocaleFilterVariables.m
+++ b/ownCloudSDK/Locale/OCLocaleFilterVariables.m
@@ -111,7 +111,7 @@
 
 	if (_sourcesByVariableName != nil)
 	{
-		for (NSString *variableName in _valueByVariableName)
+		for (NSString *variableName in _sourcesByVariableName)
 		{
 			NSRange range;
 
@@ -134,8 +134,14 @@
 					}
 				}
 			} while(range.location != NSNotFound);
+		}
+	}
 
-			localizedString = [localizedString stringByReplacingOccurrencesOfString:variableName withString:_valueByVariableName[variableName]];
+	NSDictionary<NSString *, NSString *> *customValuesByVariables = nil;
+
+	if ((customValuesByVariables = options[OCLocaleOptionKeyVariables]) != nil) {
+		for (NSString *variableName in customValuesByVariables) {
+			localizedString = [localizedString stringByReplacingOccurrencesOfString:variableName withString:customValuesByVariables[variableName]];
 		}
 	}
 
@@ -143,3 +149,5 @@
 }
 
 @end
+
+OCLocaleOptionKey OCLocaleOptionKeyVariables = @"variables";

--- a/ownCloudSDK/Locale/OCLocaleFilterVariables.m
+++ b/ownCloudSDK/Locale/OCLocaleFilterVariables.m
@@ -141,7 +141,7 @@
 
 	if ((customValuesByVariables = options[OCLocaleOptionKeyVariables]) != nil) {
 		for (NSString *variableName in customValuesByVariables) {
-			localizedString = [localizedString stringByReplacingOccurrencesOfString:variableName withString:customValuesByVariables[variableName]];
+			localizedString = [localizedString stringByReplacingOccurrencesOfString:[NSString stringWithFormat:@"{{%@}}", variableName] withString:customValuesByVariables[variableName]];
 		}
 	}
 

--- a/ownCloudSDK/Lock Manager/OCLockRequest.h
+++ b/ownCloudSDK/Lock Manager/OCLockRequest.h
@@ -35,9 +35,11 @@ typedef BOOL(^OCLockNeededHandler)(OCLockRequest *request);
 
 @property(strong,nullable) OCLock *lock;
 
+@property(assign) BOOL returnAfterFirstAttempt;
 @property(assign) BOOL invalidated;
 
-- (instancetype)initWithResourceIdentifier:(OCLockResourceIdentifier)resourceIdentifier acquiredHandler:(OCLockAcquiredHandler)acquiredHandler;
+- (instancetype)initWithResourceIdentifier:(OCLockResourceIdentifier)resourceIdentifier acquiredHandler:(OCLockAcquiredHandler)acquiredHandler; //!< Requests the lock, calls acquiredHandler when it could be acquired, otherwise may never call.
+- (instancetype)initWithResourceIdentifier:(OCLockResourceIdentifier)resourceIdentifier tryAcquireHandler:(OCLockAcquiredHandler)acquiredHandler; //!< Requests the lock, calls acquiredHandler after attempting to acquire the lock. Returns lock when locking is possible, otherwise returns error with code OCErrorLockInvalidated.
 
 - (void)invalidate;
 

--- a/ownCloudSDK/Lock Manager/OCLockRequest.m
+++ b/ownCloudSDK/Lock Manager/OCLockRequest.m
@@ -31,6 +31,18 @@
 	return (self);
 }
 
+- (instancetype)initWithResourceIdentifier:(OCLockResourceIdentifier)resourceIdentifier tryAcquireHandler:(OCLockAcquiredHandler)acquiredHandler
+{
+	if ((self = [super init]) != nil)
+	{
+		_resourceIdentifier = resourceIdentifier;
+		_returnAfterFirstAttempt = YES;
+		self.acquiredHandler = acquiredHandler;
+	}
+
+	return (self);
+}
+
 - (void)invalidate
 {
 	self.invalidated = YES;

--- a/ownCloudSDK/OCMacros.h
+++ b/ownCloudSDK/OCMacros.h
@@ -23,6 +23,7 @@
 
 #define OCLocalizedString(key,comment) [OCLocale localizeString:key bundleOfClass:[self class]]
 #define OCLocalized(key) [OCLocale localizeString:key bundleOfClass:[self class]]
+#define OCLocalizedFormat(key,variables) [OCLocale localizeString:key bundleOfClass:[self class] options:@{ OCLocaleOptionKeyVariables : variables }]
 
 // Macros to simplify usage of dispatch groups (and allow switching to more efficient mechanisms in the future)
 #define OCWaitInit(label) 	  	dispatch_group_t label = dispatch_group_create()

--- a/ownCloudSDK/OCMacros.h
+++ b/ownCloudSDK/OCMacros.h
@@ -19,8 +19,10 @@
 #ifndef OCMacros_h
 #define OCMacros_h
 
-#define OCLocalizedString(key,comment) NSLocalizedStringFromTableInBundle(key, @"Localizable", [NSBundle bundleForClass:[self class]], comment)
-#define OCLocalized(key) NSLocalizedStringFromTableInBundle(key, @"Localizable", [NSBundle bundleForClass:[self class]], nil)
+#import "OCLocale.h"
+
+#define OCLocalizedString(key,comment) [OCLocale localizeString:key bundleOfClass:[self class]]
+#define OCLocalized(key) [OCLocale localizeString:key bundleOfClass:[self class]]
 
 // Macros to simplify usage of dispatch groups (and allow switching to more efficient mechanisms in the future)
 #define OCWaitInit(label) 	  	dispatch_group_t label = dispatch_group_create()

--- a/ownCloudSDK/Resources/en.lproj/Localizable.strings
+++ b/ownCloudSDK/Resources/en.lproj/Localizable.strings
@@ -46,7 +46,7 @@
 "Server down for maintenance" = "Server down for maintenance";
 "Network unavailable" = "Network unavailable";
 "Online" = "Online";
-"Previous token refresh attempts indicated an invalid refresh token." = "Previous token refresh attempts indicated an invalid refresh_token.";
+"Previous token refresh attempts indicated an invalid refresh token." = "Previous token refresh attempts indicated an invalid refresh token.";
 "Server returns status %ld" = "Server returns status %ld";
 
 /* Account prepopulation */

--- a/ownCloudSDK/Resources/en.lproj/Localizable.strings
+++ b/ownCloudSDK/Resources/en.lproj/Localizable.strings
@@ -344,6 +344,9 @@
 // OCErrorAuthorizationCantOpenCustomSchemeURL
 "Can't open authorization URL with custom scheme." = "Can't open authorization URL with custom scheme.";
 
+// OCErrorLockInvalidated
+"Lock invalidated." = "Lock invalidated.";
+
 /* Diagnostic */
 "Files" = "Files";
 "Folders" = "Folders";

--- a/ownCloudSDK/Settings/OCClassSettings.m
+++ b/ownCloudSDK/Settings/OCClassSettings.m
@@ -138,6 +138,10 @@
 		[self clearSourceCache];
 		[NSNotificationCenter.defaultCenter postNotificationName:OCClassSettingsChangedNotification object:nil];
 	}
+
+	dispatch_async(dispatch_get_main_queue(), ^{
+		[OCLocaleFilterClassSettings.shared pullFromClassSettings];
+	});
 }
 
 - (void)insertSource:(id <OCClassSettingsSource>)source before:(nullable OCClassSettingsSourceIdentifier)beforeSourceID after:(nullable OCClassSettingsSourceIdentifier)afterSourceID

--- a/ownCloudSDK/Settings/OCClassSettings.m
+++ b/ownCloudSDK/Settings/OCClassSettings.m
@@ -456,6 +456,12 @@
 					// Add computed value
 					id computedValue = [inspectClass classSettingForOCClassSettingsKey:key];
 
+					if ((computedValue == nil) && (keySnapshot.count == 0))
+					{
+						// Avoid entries where computed == null would be the only entry
+						classSnapshot[key] = nil;
+					}
+
 					[keySnapshot addObject:@{ @"computed" : (computedValue != nil) ? computedValue : NSNull.null }];
 				}
 			}

--- a/ownCloudSDK/Vaults/Database/OCDatabase.h
+++ b/ownCloudSDK/Vaults/Database/OCDatabase.h
@@ -80,6 +80,8 @@ typedef NSString* OCDatabaseCounterIdentifier;
 	OCSQLiteDB *_sqlDB;
 }
 
+@property(readonly,nonatomic) BOOL isOpened;
+
 @property(strong) NSURL *databaseURL;
 @property(strong) NSURL *thumbnailDatabaseURL;
 

--- a/ownCloudSDK/Vaults/Database/OCDatabase.m
+++ b/ownCloudSDK/Vaults/Database/OCDatabase.m
@@ -218,6 +218,11 @@
 	}];
 }
 
+- (BOOL)isOpened
+{
+	return (_openCount > 0);
+}
+
 #pragma mark - Transactions
 - (void)performBatchUpdates:(NSError *(^)(OCDatabase *database))updates completionHandler:(OCDatabaseCompletionHandler)completionHandler
 {

--- a/ownCloudSDK/Vaults/Database/SQLite/OCSQLiteDB.m
+++ b/ownCloudSDK/Vaults/Database/SQLite/OCSQLiteDB.m
@@ -26,6 +26,7 @@
 #import "OCMacros.h"
 #import "OCSQLiteQuery+Private.h"
 #import "NSProgress+OCExtensions.h"
+#import "OCCoreManager.h"
 
 #import "OCExtension+License.h"
 
@@ -70,7 +71,7 @@ static NSMutableDictionary<NSString *, NSNumber *> *sOCSQliteDBSharedRunLoopThre
 
 		_journalMode = OCSQLiteJournalModeDelete; // (SQLite default)
 
-		self.cacheStatements = YES;
+		self.cacheStatements = (OCCoreManager.sharedCoreManager.memoryConfiguration != OCCoreMemoryConfigurationMinimum);
 
 		#if TARGET_OS_IOS
 		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(shrinkMemory) name:UIApplicationDidReceiveMemoryWarningNotification object:nil];

--- a/ownCloudSDK/Vaults/OCVault.m
+++ b/ownCloudSDK/Vaults/OCVault.m
@@ -26,6 +26,8 @@
 #import "OCHTTPPipelineManager.h"
 #import "OCVault+Internal.h"
 #import "OCEventQueue.h"
+#import "OCCoreUpdateScheduleRecord.h"
+#import "OCCore+ItemList.h"
 #import "OCCore+SyncEngine.h"
 #import "OCFeatureAvailability.h"
 #import "OCHTTPPolicyManager.h"
@@ -227,7 +229,8 @@
 	if (_keyValueStore == nil)
 	{
 		_keyValueStore = [OCKeyValueStore sharedWithURL:self.keyValueStoreURL identifier:self.uuid.UUIDString owner:nil];
-		[_keyValueStore registerClass:[OCEventQueue class] forKey:OCKeyValueStoreKeyOCCoreSyncEventsQueue];
+		[_keyValueStore registerClass:OCEventQueue.class forKey:OCKeyValueStoreKeyOCCoreSyncEventsQueue];
+		[_keyValueStore registerClass:OCCoreUpdateScheduleRecord.class forKey:OCKeyValueStoreKeyCoreUpdateScheduleRecord];
 	}
 
 	return (_keyValueStore);

--- a/ownCloudSDK/ownCloudSDK.h
+++ b/ownCloudSDK/ownCloudSDK.h
@@ -30,6 +30,11 @@ FOUNDATION_EXPORT const unsigned char ownCloudSDKVersionString[];
 #import <ownCloudSDK/OCMacros.h>
 #import <ownCloudSDK/OCFeatureAvailability.h>
 
+#import <ownCloudSDK/OCLocale.h>
+#import <ownCloudSDK/OCLocaleFilter.h>
+#import <ownCloudSDK/OCLocaleFilterClassSettings.h>
+#import <ownCloudSDK/OCLocaleFilterVariables.h>
+
 #import <ownCloudSDK/NSError+OCError.h>
 #import <ownCloudSDK/OCHTTPStatus.h>
 #import <ownCloudSDK/NSError+OCHTTPStatus.h>


### PR DESCRIPTION
## Description
- Infinite PROPFIND: add support for dav > propfind > depth_infinity capability
- OCLocale: modular localization system replacing direct system localization calls, allowing overrides via MDM and Branding.plist, adding variable support
- OCCore+FileProvider: add handling for edge case when the database is not available or not open, preventing a hang
- OCCore+ItemList: implement coordinated scan for changes
        - synchronizes scans for changes across processes
        - prioritizes scans, giving the app highest and the fileprovider second highest priority
        - consolidate related log messages under ScanChanges tag (including PollForChanges and UpdateScan)
- OCLock: add support for trying to acquire a lock and immediately returning with the result, with a new OCErrorLockInvalidated error code in case the lock couldn't be acquired
- OCSQLiteDB: disable statement caching in minimum memory configuration
- Browser Session Class: add AWBrowser to simplify configuration for AirWatch browser
- Class Settings: metadata type corrections; no longer output "computed: '<null>'" entries for class settings in the LogIntro if it is the only entry for that MDM parameter

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
