### PR TITLE
[fix/sync-hangs] Detect hanging Sync Actions and restart them

### DIFF
--- a/ownCloudSDK/Connection/OCConnection.h
+++ b/ownCloudSDK/Connection/OCConnection.h
@@ -54,6 +54,8 @@ typedef NSString* OCConnectionEndpointURLOption NS_TYPED_ENUM;
 typedef NSString* OCConnectionValidatorFlag NS_TYPED_ENUM;
 typedef NSDictionary<OCItemPropertyName,OCHTTPStatus*>* OCConnectionPropertyUpdateResult;
 
+typedef NSDictionary<OCConnectionOptionKey,id>* OCConnectionOptions;
+
 typedef NSString* OCConnectionActionUpdateKey NS_TYPED_ENUM;
 typedef NSDictionary<OCConnectionActionUpdateKey,id>* OCConnectionActionUpdate;
 
@@ -211,20 +213,20 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)shouldConsiderMaintenanceModeIndicationFromResponse:(OCHTTPResponse *)response;
 
 #pragma mark - Metadata actions
-- (nullable NSProgress *)retrieveItemListAtLocation:(OCLocation *)location depth:(NSUInteger)depth options:(nullable NSDictionary<OCConnectionOptionKey,id> *)options completionHandler:(void(^)(NSError * _Nullable error, NSArray <OCItem *> * _Nullable items))completionHandler; //!< Retrieves the items at the specified path with options
-- (nullable NSProgress *)retrieveItemListAtLocation:(OCLocation *)location depth:(NSUInteger)depth options:(nullable NSDictionary<OCConnectionOptionKey,id> *)options resultTarget:(OCEventTarget *)eventTarget; //!< Retrieves the items at the specified path, with options to schedule on the background queue and with a "not before" date.
+- (nullable NSProgress *)retrieveItemListAtLocation:(OCLocation *)location depth:(NSUInteger)depth options:(nullable OCConnectionOptions)options completionHandler:(void(^)(NSError * _Nullable error, NSArray <OCItem *> * _Nullable items))completionHandler; //!< Retrieves the items at the specified path with options
+- (nullable NSProgress *)retrieveItemListAtLocation:(OCLocation *)location depth:(NSUInteger)depth options:(nullable OCConnectionOptions)options resultTarget:(OCEventTarget *)eventTarget; //!< Retrieves the items at the specified path, with options to schedule on the background queue and with a "not before" date.
 
 #pragma mark - Actions
-- (nullable OCProgress *)createFolder:(NSString *)folderName inside:(OCItem *)parentItem options:(nullable NSDictionary<OCConnectionOptionKey,id> *)options resultTarget:(OCEventTarget *)eventTarget;
+- (nullable OCProgress *)createFolder:(NSString *)folderName inside:(OCItem *)parentItem options:(nullable OCConnectionOptions)options resultTarget:(OCEventTarget *)eventTarget;
 
-- (nullable OCProgress *)moveItem:(OCItem *)item to:(OCItem *)parentItem withName:(NSString *)newName options:(nullable NSDictionary<OCConnectionOptionKey,id> *)options resultTarget:(OCEventTarget *)eventTarget;
-- (nullable OCProgress *)copyItem:(OCItem *)item to:(OCItem *)parentItem withName:(NSString *)newName options:(nullable NSDictionary<OCConnectionOptionKey,id> *)options resultTarget:(OCEventTarget *)eventTarget;
+- (nullable OCProgress *)moveItem:(OCItem *)item to:(OCItem *)parentItem withName:(NSString *)newName options:(nullable OCConnectionOptions)options resultTarget:(OCEventTarget *)eventTarget;
+- (nullable OCProgress *)copyItem:(OCItem *)item to:(OCItem *)parentItem withName:(NSString *)newName options:(nullable OCConnectionOptions)options resultTarget:(OCEventTarget *)eventTarget;
 
 - (nullable OCProgress *)deleteItem:(OCItem *)item requireMatch:(BOOL)requireMatch resultTarget:(OCEventTarget *)eventTarget;
 
-- (nullable OCProgress *)downloadItem:(OCItem *)item to:(nullable NSURL *)targetURL options:(nullable NSDictionary<OCConnectionOptionKey,id> *)options resultTarget:(OCEventTarget *)eventTarget;
+- (nullable OCProgress *)downloadItem:(OCItem *)item to:(nullable NSURL *)targetURL options:(nullable OCConnectionOptions)options resultTarget:(OCEventTarget *)eventTarget;
 
-- (nullable OCProgress *)updateItem:(OCItem *)item properties:(nullable NSArray <OCItemPropertyName> *)properties options:(nullable NSDictionary *)options resultTarget:(OCEventTarget *)eventTarget;
+- (nullable OCProgress *)updateItem:(OCItem *)item properties:(nullable NSArray <OCItemPropertyName> *)properties options:(nullable OCConnectionOptions)options resultTarget:(OCEventTarget *)eventTarget;
 
 - (nullable NSProgress *)retrieveThumbnailFor:(OCItem *)item to:(nullable NSURL *)localThumbnailURL maximumSize:(CGSize)size resultTarget:(OCEventTarget *)eventTarget;
 - (nullable NSProgress *)retrieveThumbnailFor:(OCItem *)item to:(nullable NSURL *)localThumbnailURL maximumSize:(CGSize)size waitForConnectivity:(BOOL)waitForConnectivity resultTarget:(OCEventTarget *)eventTarget;
@@ -244,7 +246,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Action: Upload
 @interface OCConnection (Upload)
-- (nullable OCProgress *)uploadFileFromURL:(NSURL *)sourceURL withName:(nullable NSString *)fileName to:(OCItem *)newParentDirectory replacingItem:(nullable OCItem *)replacedItem options:(nullable NSDictionary<OCConnectionOptionKey,id> *)options resultTarget:(OCEventTarget *)eventTarget;
+- (nullable OCProgress *)uploadFileFromURL:(NSURL *)sourceURL withName:(nullable NSString *)fileName to:(OCItem *)newParentDirectory replacingItem:(nullable OCItem *)replacedItem options:(nullable OCConnectionOptions)options resultTarget:(OCEventTarget *)eventTarget;
 @end
 
 #pragma mark - SIGNALS
@@ -502,6 +504,9 @@ extern OCConnectionActionUpdateKey OCConnectionActionUpdateProgressRange; //!< N
 extern OCConnectionActionUpdateKey OCConnectionActionUpdateProgress; //!< NSProgress object providing information on the current progress, may be mapped to
 
 NS_ASSUME_NONNULL_END
+
+// This macro infers (extracts) an OCActionTrackingID from the provided options and eventTarget
+#define OCConnectionInferActionTrackingID(options,eventTarget) (((options != nil) && (options[OCConnectionOptionActionTrackingID] != nil)) ? options[OCConnectionOptionActionTrackingID] : (((eventTarget != nil) && (eventTarget.userInfo[OCEventUserInfoKeyActionTrackingID] != nil)) ? eventTarget.userInfo[OCEventUserInfoKeyActionTrackingID] : nil))
 
 #import "OCClassSettings.h"
 

--- a/ownCloudSDK/Core/OCCore.m
+++ b/ownCloudSDK/Core/OCCore.m
@@ -500,6 +500,9 @@ INCLUDE_IN_CLASS_SETTINGS_SNAPSHOTS(OCCore)
 				});
 			}
 
+			// Find and restart stuck sync records
+			[self restartStuckSyncRecordsWithFilter:nil];
+
 			// Get latest sync anchor
 			if (startError == nil)
 			{

--- a/ownCloudSDK/Core/Sync/Actions/OCSyncAction.h
+++ b/ownCloudSDK/Core/Sync/Actions/OCSyncAction.h
@@ -61,6 +61,8 @@ typedef NS_ENUM(NSUInteger, OCCoreSyncInstruction)
 @property(strong) NSArray<OCSyncActionCategory> *categories; //!< Categories this action belongs to.
 
 #pragma mark - Persisted properties
+@property(strong,nullable) OCActionTrackingID actionTrackingID; //!< Action tracking ID used to identify requests, responses and events belonging to this action.
+
 @property(strong) OCItem *localItem; //!< Locally managed OCItem that this action is performed on (persisted)
 @property(readonly,nonatomic,nullable) OCItem *latestVersionOfLocalItem; //!< The latest version of the item, retrieved from the database
 @property(readonly,nonatomic,nullable) OCItem *archivedServerItem; //!< Archived OCItem describing the (known) server item at the time the action was committed. (persisted)

--- a/ownCloudSDK/Core/Sync/Actions/OCSyncAction.m
+++ b/ownCloudSDK/Core/Sync/Actions/OCSyncAction.m
@@ -56,6 +56,8 @@
 			OCLogError(@"BUG: sync action %@ has a nil +identifier", self.class);
 		}
 
+		_actionTrackingID = NSUUID.UUID.UUIDString;
+
 		_localItem = item;
 		_archivedServerItem = ((item.remoteItem != nil) ? item.remoteItem : item);
 
@@ -370,6 +372,8 @@
 	[coder encodeInteger:_actionEventType forKey:@"actionEventType"];
 	[coder encodeObject:_categories forKey:@"categories"];
 
+	[coder encodeObject:_actionTrackingID forKey:@"trackingID"];
+
 	[self encodeActionData:coder];
 }
 
@@ -389,6 +393,8 @@
 		_localizedDescription = [decoder decodeObjectOfClass:[NSString class] forKey:@"localizedDescription"];
 		_actionEventType = [decoder decodeIntegerForKey:@"actionEventType"];
 		_categories = [decoder decodeObjectOfClasses:[[NSSet alloc] initWithObjects:[NSArray class], [NSString class], nil] forKey:@"categories"];
+
+		_actionTrackingID = [decoder decodeObjectOfClass:NSString.class forKey:@"trackingID"];
 
 		[self decodeActionData:decoder];
 	}
@@ -420,12 +426,12 @@
 {
 	NSString *internals = self.internalsDescription;
 
-	return ([NSString stringWithFormat:@"<%@: %p, identifier: %@%@, description: %@>", NSStringFromClass(self.class), self, _identifier, ((internals != nil) ? [NSString stringWithFormat:@", %@", internals] : @""), self.localizedDescription]);
+	return ([NSString stringWithFormat:@"<%@: %p, identifier: %@%@, ATID: %@, description: %@>", NSStringFromClass(self.class), self, _identifier, ((internals != nil) ? [NSString stringWithFormat:@", %@", internals] : @""), _actionTrackingID, self.localizedDescription]);
 }
 
 - (NSString *)privacyMaskedDescription
 {
-	return ([NSString stringWithFormat:@"<%@: %p, identifier: %@, description: %@>", NSStringFromClass(self.class), self, _identifier, OCLogPrivate(self.localizedDescription)]);
+	return ([NSString stringWithFormat:@"<%@: %p, identifier: %@, ATID: %@, description: %@>", NSStringFromClass(self.class), self, _identifier, _actionTrackingID, OCLogPrivate(self.localizedDescription)]);
 }
 
 - (NSString *)internalsDescription

--- a/ownCloudSDK/Core/Sync/OCCore+SyncEngine.h
+++ b/ownCloudSDK/Core/Sync/OCCore+SyncEngine.h
@@ -80,6 +80,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)removeSyncRecords:(NSArray <OCSyncRecord *> *)syncRecords completionHandler:(nullable OCDatabaseCompletionHandler)completionHandler;
 - (void)updatePublishedSyncRecordActivities;
 
+#pragma mark - Auto-Healing
+- (void)restartStuckSyncRecordsWithFilter:(nullable NSArray<OCSyncRecord *> * _Nullable (^)(NSError * _Nullable error, NSArray<OCSyncRecord *> * _Nullable stuckRecords))filter;
+
 @end
 
 extern OCEventUserInfoKey OCEventUserInfoKeySyncRecordID;

--- a/ownCloudSDK/Core/Sync/Record/OCSyncRecord.m
+++ b/ownCloudSDK/Core/Sync/Record/OCSyncRecord.m
@@ -24,6 +24,7 @@
 #import "OCWaitConditionIssue.h"
 #import "OCSyncRecordActivity.h"
 #import "OCSignalManager.h"
+#import "OCProxyProgress.h"
 
 @implementation OCSyncRecord
 
@@ -88,31 +89,31 @@
 	return ([NSKeyedArchiver archivedDataWithRootObject:self]);
 }
 
-- (void)addProgress:(OCProgress *)progress
+- (void)addProgress:(OCProgress *)progressToAdd
 {
-	if (progress != nil)
+	if (progressToAdd != nil)
 	{
 		if (_progress == nil)
 		{
-			self.progress = progress;
+			self.progress = progressToAdd;
 		}
 		else
 		{
-			_progress.userInfo = @{ OCSyncRecordProgressUserInfoKeySource : progress };
+			_progress.userInfo = @{ OCSyncRecordProgressUserInfoKeySource : progressToAdd };
 
-			if (progress.progress != nil)
+			if (progressToAdd.progress != nil)
 			{
 				if (_progress.progress == nil)
 				{
-					_progress.progress = progress.progress;
+					_progress.progress = progressToAdd.progress;
 				}
 				else
 				{
-					_progress.progress.localizedDescription = progress.progress.localizedDescription;
-					_progress.progress.localizedAdditionalDescription = progress.progress.localizedAdditionalDescription;
+					_progress.progress.localizedDescription = progressToAdd.progress.localizedDescription;
+					_progress.progress.localizedAdditionalDescription = progressToAdd.progress.localizedAdditionalDescription;
 
 					_progress.progress.totalUnitCount += 200;
-					[_progress.progress addChild:progress.progress withPendingUnitCount:200];
+					[_progress.progress addChild:[OCProxyProgress cloneProgress:progressToAdd.progress] withPendingUnitCount:200]; // Clone progress to avoid possibility of exception "NSProgress 0x... was already the child of another progress 0x..."
 				}
 			}
 		}

--- a/ownCloudSDK/Events/OCEvent.h
+++ b/ownCloudSDK/Events/OCEvent.h
@@ -135,6 +135,7 @@ extern OCEventUserInfoKey OCEventUserInfoKeyItem;
 extern OCEventUserInfoKey OCEventUserInfoKeyItemVersionIdentifier;
 extern OCEventUserInfoKey OCEventUserInfoKeySelector;
 extern OCEventUserInfoKey OCEventUserInfoDriveID;
+extern OCEventUserInfoKey OCEventUserInfoKeyActionTrackingID;
 
 NS_ASSUME_NONNULL_END
 

--- a/ownCloudSDK/Events/OCEvent.m
+++ b/ownCloudSDK/Events/OCEvent.m
@@ -330,3 +330,4 @@ OCEventUserInfoKey OCEventUserInfoKeyItem = @"item";
 OCEventUserInfoKey OCEventUserInfoKeyItemVersionIdentifier = @"itemVersionIdentifier";
 OCEventUserInfoKey OCEventUserInfoKeySelector = @"selector";
 OCEventUserInfoKey OCEventUserInfoDriveID = @"drive-id";
+OCEventUserInfoKey OCEventUserInfoKeyActionTrackingID = @"actionTrackingID";

--- a/ownCloudSDK/HTTP/Pipeline/OCHTTPPipelineBackend.h
+++ b/ownCloudSDK/HTTP/Pipeline/OCHTTPPipelineBackend.h
@@ -67,6 +67,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSNumber *)numberOfRequestsWithState:(OCHTTPPipelineTaskState)state inPipeline:(OCHTTPPipeline *)pipeline partition:(nullable OCHTTPPipelinePartitionID)partitionID error:(NSError * _Nullable *)outDBError;
 - (NSNumber *)numberOfRequestsInPipeline:(OCHTTPPipeline *)pipeline partition:(OCHTTPPipelinePartitionID)partitionID error:(NSError * _Nullable *)outDBError;
 
+- (void)retrieveActionTrackingIDsForPartition:(OCHTTPPipelinePartitionID)partitionID resultHandler:(void(^)(NSError * _Nullable error, NSSet<OCActionTrackingID> * _Nullable trackingIDs, NSNumber * _Nullable totalNumberOfRequestsInBackend))resultHandler;
+
 #pragma mark - Debugging
 - (void)dumpDBTable;
 

--- a/ownCloudSDK/HTTP/Request/OCHTTPRequest.h
+++ b/ownCloudSDK/HTTP/Request/OCHTTPRequest.h
@@ -69,6 +69,8 @@ typedef NSDictionary<OCHTTPRequestResumeInfoKey,id>* OCHTTPRequestResumeInfo;
 
 @property(strong,readonly) OCHTTPRequestID identifier; //!< Unique ID (auto-generated) for every request
 
+@property(strong) OCActionTrackingID actionTrackingID; 	//!< Action tracking ID that can be used to associate a request to an action / activity
+
 @property(strong) OCProgress *progress;			//!< Resolvable progress object that tracks progress and provides cancellation ability/status
 
 @property(strong) OCHTTPMethod method;			//!< The HTTP method to use to request the URL

--- a/ownCloudSDK/HTTP/Request/OCHTTPRequest.m
+++ b/ownCloudSDK/HTTP/Request/OCHTTPRequest.m
@@ -600,7 +600,7 @@
 
 - (NSString *)description
 {
-	return ([NSString stringWithFormat:@"<%@: %p, identifier: %@, method: %@, url: %@, effectiveURL: %@%@%@>", NSStringFromClass(self.class), self, self.identifier, self.method, self.url, self.effectiveURL, ((self.bodyData != nil) ? [NSString stringWithFormat:@", bodyData=%lu bytes", self.bodyData.length] : @""), ((self.bodyURL != nil) ? [NSString stringWithFormat:@", bodyURL=%@", self.bodyURL.absoluteString] : @"")]);
+	return ([NSString stringWithFormat:@"<%@: %p, identifier: %@, method: %@, ATID: %@, url: %@, effectiveURL: %@%@%@>", NSStringFromClass(self.class), self, self.identifier, self.method, self.actionTrackingID, self.url, self.effectiveURL, ((self.bodyData != nil) ? [NSString stringWithFormat:@", bodyData=%lu bytes", self.bodyData.length] : @""), ((self.bodyURL != nil) ? [NSString stringWithFormat:@", bodyURL=%@", self.bodyURL.absoluteString] : @"")]);
 }
 
 #pragma mark - Secure Coding
@@ -660,6 +660,8 @@
 		self.isNonCritial 	= [decoder decodeBoolForKey:@"isNonCritial"];
 		self.cancelled		= [decoder decodeBoolForKey:@"cancelled"];
 
+		self.actionTrackingID	= [decoder decodeObjectOfClass:NSString.class forKey:@"actionTrackingID"];
+
 		if ((resultHandlerActionString = [decoder decodeObjectOfClass:[NSString class] forKey:@"resultHandlerAction"]) != nil)
 		{
 			self.resultHandlerAction = NSSelectorFromString(resultHandlerActionString);
@@ -716,6 +718,8 @@
 
 	[coder encodeBool:_isNonCritial 	forKey:@"isNonCritial"];
 	[coder encodeBool:_cancelled 		forKey:@"cancelled"];
+
+	[coder encodeObject:_actionTrackingID	forKey:@"actionTrackingID"];
 
 	[coder encodeObject:NSStringFromSelector(_resultHandlerAction) forKey:@"resultHandlerAction"];
 }

--- a/ownCloudSDK/Vaults/Database/OCDatabase+Schemas.m
+++ b/ownCloudSDK/Vaults/Database/OCDatabase+Schemas.m
@@ -24,16 +24,6 @@
 #import "OCItem+OCTypeAlias.h"
 #import "OCDatabase+Scans.h"
 
-#define INSTALL_TRANSACTION_ERROR_COLLECTION_RESULT_HANDLER \
-	__block NSError *transactionError = nil;  \
-	OCSQLiteDBResultHandler resultHandler = ^(OCSQLiteDB *db, NSError *error, OCSQLiteTransaction *transaction, OCSQLiteResultSet *resultSet) {  \
-		if (error != nil)  \
-		{  \
-			transactionError = error;  \
-		}  \
-	};
-
-
 @implementation OCDatabase (Schemas)
 
 #pragma mark - Schemas

--- a/ownCloudSDK/Vaults/Database/OCDatabase.h
+++ b/ownCloudSDK/Vaults/Database/OCDatabase.h
@@ -148,6 +148,7 @@ typedef NSString* OCDatabaseCounterIdentifier;
 - (void)numberOfSyncRecordsOnSyncLaneID:(OCSyncLaneID)laneID completionHandler:(OCDatabaseRetrieveSyncRecordCountCompletionHandler)completionHandler;
 
 - (void)retrieveSyncRecordIDsWithCompletionHandler:(OCDatabaseRetrieveSyncRecordIDsCompletionHandler)completionHandler;
+- (void)retrieveSyncRecordIDsWithPendingEventsWithCompletionHandler:(OCDatabaseRetrieveSyncRecordIDsCompletionHandler)completionHandler;
 
 - (void)retrieveSyncRecordForID:(OCSyncRecordID)recordID completionHandler:(OCDatabaseRetrieveSyncRecordCompletionHandler)completionHandler;
 - (void)retrieveSyncRecordAfterID:(OCSyncRecordID)recordID onLaneID:(OCSyncLaneID)laneID completionHandler:(OCDatabaseRetrieveSyncRecordCompletionHandler)completionHandler;

--- a/ownCloudSDK/Vaults/Database/OCDatabase.m
+++ b/ownCloudSDK/Vaults/Database/OCDatabase.m
@@ -1536,6 +1536,31 @@
 	}]];
 }
 
+- (void)retrieveSyncRecordIDsWithPendingEventsWithCompletionHandler:(OCDatabaseRetrieveSyncRecordIDsCompletionHandler)completionHandler
+{
+	[self.sqlDB executeQuery:[OCSQLiteQuery querySelectingColumns:@[ @"recordID" ] fromTable:OCDatabaseTableNameEvents where:nil orderBy:nil resultHandler:^(OCSQLiteDB *db, NSError *error, OCSQLiteTransaction *transaction, OCSQLiteResultSet *resultSet) {
+		NSError *iterationError = error;
+		NSMutableSet<OCSyncRecordID> *syncRecordIDs = [NSMutableSet new];
+
+		if (error == nil)
+		{
+			[resultSet iterateUsing:^(OCSQLiteResultSet *resultSet, NSUInteger line, NSDictionary<NSString *,id<NSObject>> *rowDictionary, BOOL *stop) {
+				OCSyncRecordID syncRecordID;
+
+				if ((syncRecordID = OCTypedCast(rowDictionary[@"recordID"], NSNumber)) != nil)
+				{
+					[syncRecordIDs addObject:syncRecordID];
+				}
+			} error:&iterationError];
+		}
+
+		if (completionHandler != nil)
+		{
+			completionHandler(self, iterationError, syncRecordIDs);
+		}
+	}]];
+}
+
 - (void)retrieveSyncRecordForID:(OCSyncRecordID)recordID completionHandler:(OCDatabaseRetrieveSyncRecordCompletionHandler)completionHandler
 {
 	if (recordID == nil)

--- a/ownCloudSDK/Vaults/Database/SQLite/Queries/OCSQLiteTransaction.h
+++ b/ownCloudSDK/Vaults/Database/SQLite/Queries/OCSQLiteTransaction.h
@@ -51,4 +51,13 @@ typedef NS_ENUM(NSUInteger, OCSQLiteTransactionType) //!< See https://www.sqlite
 
 extern NSErrorUserInfoKey OCSQLiteTransactionFailedRequestKey;
 
+#define INSTALL_TRANSACTION_ERROR_COLLECTION_RESULT_HANDLER \
+	__block NSError *transactionError = nil;  \
+	OCSQLiteDBResultHandler resultHandler = ^(OCSQLiteDB *db, NSError *error, OCSQLiteTransaction *transaction, OCSQLiteResultSet *resultSet) {  \
+		if (error != nil)  \
+		{  \
+			transactionError = error;  \
+		}  \
+	};
+
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## Description
Find hanging Sync Actions in the Sync Journal and automatically restart them.

The criteria used is if a Sync Action is running but has no HTTP requests or events queued for delivery with its `OCActionTrackingID` or `OCSyncRecordID`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
