### PR TITLE
[fix/tus-cancellation] Detect and terminate spurious TUS upload jobs

### DIFF
--- a/ownCloudSDK/Core/Sync/Actions/Upload/OCSyncActionUpload.m
+++ b/ownCloudSDK/Core/Sync/Actions/Upload/OCSyncActionUpload.m
@@ -251,7 +251,7 @@ OCSYNCACTION_REGISTER_ISSUETEMPLATES
 							lastModificationDate,								OCConnectionOptionLastModificationDateKey,
 							cellularSwitchID,								OCConnectionOptionRequiredCellularSwitchKey,
 							@(((NSNumber *)self.options[OCConnectionOptionForceReplaceKey]).boolValue),	OCConnectionOptionForceReplaceKey,
-							[NSString stringWithFormat:@"sync.upload:%@", syncContext.syncRecord.recordID],	OCConnectionOptionActionTrackingID,
+							OCActionTrackingIDFromSyncRecordID(syncContext.syncRecord.recordID),		OCConnectionOptionActionTrackingID,
 							syncContext.syncRecord.recordID,						OCConnectionOptionSyncRecordID,		// not using @{} syntax here: if recordID is nil for any reason, that'd throw
 							self.importFileChecksum, 	 						OCConnectionOptionChecksumKey,		// not using @{} syntax here: if importFileChecksum is nil for any reason, that'd throw
 						nil];

--- a/ownCloudSDK/Core/Sync/Record/OCSyncRecord.h
+++ b/ownCloudSDK/Core/Sync/Record/OCSyncRecord.h
@@ -119,6 +119,9 @@ typedef NS_ENUM(NSInteger, OCSyncRecordState)
 
 @end
 
+OCSyncRecordID _Nullable OCSyncRecordIDFromActionTrackingID(OCActionTrackingID _Nullable actionTrackingID);
+OCActionTrackingID _Nullable OCActionTrackingIDFromSyncRecordID(OCSyncRecordID _Nullable syncRecordID);
+
 extern OCSyncActionIdentifier OCSyncActionIdentifierDeleteLocal; //!< Locally triggered deletion
 extern OCSyncActionIdentifier OCSyncActionIdentifierDeleteRemote; //!< Remotely triggered deletion
 extern OCSyncActionIdentifier OCSyncActionIdentifierDeleteLocalCopy; //!< Deletion of local copy

--- a/ownCloudSDK/Core/Sync/Record/OCSyncRecord.m
+++ b/ownCloudSDK/Core/Sync/Record/OCSyncRecord.m
@@ -327,6 +327,26 @@
 
 @end
 
+static NSString *SyncRecordIDActionTrackingIDPrefix = @"syncRecordID:";
+
+OCSyncRecordID _Nullable OCSyncRecordIDFromActionTrackingID(OCActionTrackingID _Nullable actionTrackingID)
+{
+	if (actionTrackingID == nil) { return(nil); }
+
+	if ([actionTrackingID hasPrefix:SyncRecordIDActionTrackingIDPrefix])
+	{
+		return (@([[actionTrackingID substringFromIndex:SyncRecordIDActionTrackingIDPrefix.length] integerValue]));
+	}
+
+	return (nil);
+}
+
+OCActionTrackingID _Nullable OCActionTrackingIDFromSyncRecordID(OCSyncRecordID _Nullable syncRecordID)
+{
+	if (syncRecordID == nil) { return(nil); }
+	return ([SyncRecordIDActionTrackingIDPrefix stringByAppendingString:syncRecordID.stringValue]);
+}
+
 OCSyncActionIdentifier OCSyncActionIdentifierDeleteLocal = @"deleteLocal";
 OCSyncActionIdentifier OCSyncActionIdentifierDeleteLocalCopy = @"deleteLocalCopy";
 OCSyncActionIdentifier OCSyncActionIdentifierDeleteRemote = @"deleteRemote";

--- a/ownCloudSDK/Vaults/Database/OCDatabase.h
+++ b/ownCloudSDK/Vaults/Database/OCDatabase.h
@@ -147,6 +147,8 @@ typedef NSString* OCDatabaseCounterIdentifier;
 - (void)removeSyncRecords:(NSArray <OCSyncRecord *> *)syncRecords completionHandler:(OCDatabaseCompletionHandler)completionHandler;
 - (void)numberOfSyncRecordsOnSyncLaneID:(OCSyncLaneID)laneID completionHandler:(OCDatabaseRetrieveSyncRecordCountCompletionHandler)completionHandler;
 
+- (BOOL)isValidSyncRecordID:(OCSyncRecordID)syncRecordID considerCacheValid:(BOOL)considerCacheValid; //!< Returns whether the sync record ID exists. If considerCacheValid is YES, the sync record is deemed valid already if it exists in the in-memory cache. If NO, the database is always consulted. The cache will typically provide accurate results, unless an action was cancelled from another process and the sync queue has not passed processing from the current process in the meantime.
+
 - (void)retrieveSyncRecordIDsWithCompletionHandler:(OCDatabaseRetrieveSyncRecordIDsCompletionHandler)completionHandler;
 - (void)retrieveSyncRecordIDsWithPendingEventsWithCompletionHandler:(OCDatabaseRetrieveSyncRecordIDsCompletionHandler)completionHandler;
 


### PR DESCRIPTION
## Description
Detects disconnected/spurious TUS uploads running in the HTTP backend and stop them if the Sync Action that started the upload is no longer around.

## Related Issue
https://github.com/owncloud/ios-app/pull/1351

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
