### PR TITLE
[feature/policy-upgrades] Item Policy Upgrades

### DIFF
--- a/ownCloudSDK.xcodeproj/project.pbxproj
+++ b/ownCloudSDK.xcodeproj/project.pbxproj
@@ -431,6 +431,8 @@
 		DC6CF8212195D56C0013B9F9 /* OCCore+CommandUpdate.m in Sources */ = {isa = PBXBuildFile; fileRef = DC6CF8202195D56B0013B9F9 /* OCCore+CommandUpdate.m */; };
 		DC6CF8242195D7C90013B9F9 /* OCSyncActionUpdate.h in Headers */ = {isa = PBXBuildFile; fileRef = DC6CF8222195D7C90013B9F9 /* OCSyncActionUpdate.h */; };
 		DC6CF8252195D7C90013B9F9 /* OCSyncActionUpdate.m in Sources */ = {isa = PBXBuildFile; fileRef = DC6CF8232195D7C90013B9F9 /* OCSyncActionUpdate.m */; };
+		DC6D387F2C4E4ED300169BF5 /* OCWaitConditionAvailableOffline.h in Headers */ = {isa = PBXBuildFile; fileRef = DC6D387D2C4E4ED300169BF5 /* OCWaitConditionAvailableOffline.h */; };
+		DC6D38802C4E4ED300169BF5 /* OCWaitConditionAvailableOffline.m in Sources */ = {isa = PBXBuildFile; fileRef = DC6D387E2C4E4ED300169BF5 /* OCWaitConditionAvailableOffline.m */; };
 		DC6D51D924A8BC4D006B75E6 /* OCNetworkMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = DC6D51D724A8BC4C006B75E6 /* OCNetworkMonitor.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DC6D51DA24A8BC4D006B75E6 /* OCNetworkMonitor.m in Sources */ = {isa = PBXBuildFile; fileRef = DC6D51D824A8BC4C006B75E6 /* OCNetworkMonitor.m */; };
 		DC6DB88221C26F4D00189B21 /* XCTestCase+Tagging.m in Sources */ = {isa = PBXBuildFile; fileRef = DC6DB88121C26F4D00189B21 /* XCTestCase+Tagging.m */; };
@@ -1211,6 +1213,7 @@
 		DC27BBBE230498C3002CC2F8 /* OCHTTPCookieStorage.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OCHTTPCookieStorage.m; sourceTree = "<group>"; };
 		DC27BBC12304A7CE002CC2F8 /* NSHTTPCookie+OCCookies.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSHTTPCookie+OCCookies.h"; sourceTree = "<group>"; };
 		DC27BBC22304A7CE002CC2F8 /* NSHTTPCookie+OCCookies.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSHTTPCookie+OCCookies.m"; sourceTree = "<group>"; };
+		DC27EEF52C47C71C00EBDD26 /* Item Policies.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "Item Policies.md"; sourceTree = "<group>"; };
 		DC28F821294B6DE600AC4013 /* OCItemPolicy+OCDataItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OCItemPolicy+OCDataItem.h"; sourceTree = "<group>"; };
 		DC28F822294B6DE600AC4013 /* OCItemPolicy+OCDataItem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "OCItemPolicy+OCDataItem.m"; sourceTree = "<group>"; };
 		DC29F4C024323C4900347658 /* OCMessageTemplate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OCMessageTemplate.h; sourceTree = "<group>"; };
@@ -1480,6 +1483,8 @@
 		DC6CF8202195D56B0013B9F9 /* OCCore+CommandUpdate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "OCCore+CommandUpdate.m"; sourceTree = "<group>"; };
 		DC6CF8222195D7C90013B9F9 /* OCSyncActionUpdate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OCSyncActionUpdate.h; sourceTree = "<group>"; };
 		DC6CF8232195D7C90013B9F9 /* OCSyncActionUpdate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OCSyncActionUpdate.m; sourceTree = "<group>"; };
+		DC6D387D2C4E4ED300169BF5 /* OCWaitConditionAvailableOffline.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OCWaitConditionAvailableOffline.h; sourceTree = "<group>"; };
+		DC6D387E2C4E4ED300169BF5 /* OCWaitConditionAvailableOffline.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OCWaitConditionAvailableOffline.m; sourceTree = "<group>"; };
 		DC6D51D724A8BC4C006B75E6 /* OCNetworkMonitor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OCNetworkMonitor.h; sourceTree = "<group>"; };
 		DC6D51D824A8BC4C006B75E6 /* OCNetworkMonitor.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OCNetworkMonitor.m; sourceTree = "<group>"; };
 		DC6DB88021C26F4D00189B21 /* XCTestCase+Tagging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTestCase+Tagging.h"; sourceTree = "<group>"; };
@@ -1979,7 +1984,6 @@
 		DCFC9EDB28003F0D005D9144 /* GARemoteItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GARemoteItem.m; sourceTree = "<group>"; };
 		DCFC9EDF28004791005D9144 /* OCDataSourceComposition.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OCDataSourceComposition.h; sourceTree = "<group>"; };
 		DCFC9EE028004791005D9144 /* OCDataSourceComposition.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OCDataSourceComposition.m; sourceTree = "<group>"; };
-		DCFD2CF62C1AF2E400DE439E /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		DCFE3B7827A1666B00939415 /* GAGraphObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GAGraphObject.h; sourceTree = "<group>"; };
 		DCFE3B7C27A1669300939415 /* GAGraphContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GAGraphContext.h; sourceTree = "<group>"; };
 		DCFE3B7D27A1669300939415 /* GAGraphContext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GAGraphContext.m; sourceTree = "<group>"; };
@@ -2376,12 +2380,14 @@
 			children = (
 				DC19BFF021CBE28B007C20D1 /* OCWaitCondition.m */,
 				DC19BFEF21CBE28B007C20D1 /* OCWaitCondition.h */,
+				DCA35D7D24D00EC400DBE2B0 /* OCWaitCondition+Diagnostic.m */,
+				DCA35D7C24D00EC400DBE2B0 /* OCWaitCondition+Diagnostic.h */,
 				DC24F8E721E2B3EF00C9119C /* OCWaitConditionIssue.m */,
 				DC24F8E621E2B3EF00C9119C /* OCWaitConditionIssue.h */,
 				DC76500B2404703A00201812 /* OCWaitConditionMetaDataRefresh.m */,
 				DC76500A2404703A00201812 /* OCWaitConditionMetaDataRefresh.h */,
-				DCA35D7D24D00EC400DBE2B0 /* OCWaitCondition+Diagnostic.m */,
-				DCA35D7C24D00EC400DBE2B0 /* OCWaitCondition+Diagnostic.h */,
+				DC6D387E2C4E4ED300169BF5 /* OCWaitConditionAvailableOffline.m */,
+				DC6D387D2C4E4ED300169BF5 /* OCWaitConditionAvailableOffline.h */,
 			);
 			path = "Wait Condition";
 			sourceTree = "<group>";
@@ -2922,7 +2928,6 @@
 		DC4B11FB220996330062BCDD /* Progress */ = {
 			isa = PBXGroup;
 			children = (
-				DCFD2CF62C1AF2E400DE439E /* README.md */,
 				DC4B11FD220996480062BCDD /* OCProgress.m */,
 				DC4B11FC220996480062BCDD /* OCProgress.h */,
 				DC8FE6FE221CAF280016BDEE /* OCProgressManager.m */,
@@ -4187,6 +4192,7 @@
 		DCE227CC22D60CF4000BE0A5 /* ItemPolicies */ = {
 			isa = PBXGroup;
 			children = (
+				DC27EEF52C47C71C00EBDD26 /* Item Policies.md */,
 				DCE227D722D612EC000BE0A5 /* OCCore+ItemPolicies.m */,
 				DCE227D622D612EC000BE0A5 /* OCCore+ItemPolicies.h */,
 				DCE227D222D60D49000BE0A5 /* OCItemPolicy.m */,
@@ -4771,6 +4777,7 @@
 				DC49B5602837DCE700DAF13B /* OCItem+OCVFSItem.h in Headers */,
 				DC72E42E2063DBF900189B9A /* OCClassSettingsFlatSourceManagedConfiguration.h in Headers */,
 				DC2F636B2239523A0063C2DA /* OCShareQuery.h in Headers */,
+				DC6D387F2C4E4ED300169BF5 /* OCWaitConditionAvailableOffline.h in Headers */,
 				DCB0A46421B922A400FAC4E9 /* OCCoreConnectionStatusSignalProvider.h in Headers */,
 				DC6CF8242195D7C90013B9F9 /* OCSyncActionUpdate.h in Headers */,
 				DC2565F12260BE3700828AA5 /* OCCertificate+PrivacyLogging.h in Headers */,
@@ -5514,6 +5521,7 @@
 				DC680586212EC27B006C3B1F /* OCExtension+License.m in Sources */,
 				DCE48DD9220E1C7B00839E97 /* OCHTTPPipelineTaskCache.m in Sources */,
 				DC701480220B0650009D4FD9 /* OCHTTPResponse.m in Sources */,
+				DC6D38802C4E4ED300169BF5 /* OCWaitConditionAvailableOffline.m in Sources */,
 				DCA35D7F24D00EC400DBE2B0 /* OCWaitCondition+Diagnostic.m in Sources */,
 				DC18897A2189AF3B00CFB3F9 /* OCClassSettingsFlatSourceEnvironment.m in Sources */,
 				DC6B0473268D1950003FDEC1 /* OCBookmark+Prepopulation.m in Sources */,

--- a/ownCloudSDK/Core/ItemPolicies/Item Policies.md
+++ b/ownCloudSDK/Core/ItemPolicies/Item Policies.md
@@ -1,0 +1,65 @@
+#  Item Policies
+
+## Introduction
+The Item Policy system in `OCCore` provides the infrastructure to run code (more generally) / process items (more specifically) in response to specific events, which can be of different scope.
+
+Currently, the Item Policy system is used to implement features like:
+
+#### Available Offline
+Automatically download files and folders that are marked as Available Offline (and keep them updated).
+
+#### Download Expiration
+Automatically removes downloaded files X seconds after they have last been used by the user.
+
+#### Vacuum
+Removes files and folders from the filesystem that belong to items that have been deleted on the server/client.
+
+#### Version Updates
+When a file is updated on the server, removes the outdated local copy if it is not used - or - automatically downloads the latest version if the local copy is currently accessed read-only.
+
+
+## Components
+The Item Policy system is built from different components:
+
+### Item Policy (`OCItemPolicy`)
+Item policies are lightweight objects that
+- target a set of items that should be processed, using an `OCQueryCondition` (`condition`)
+- are associated with an Item Policy Processor (linked by `OCItemPolicyKind`) that will process matching items (`kind`)
+- are persisted in and managed by `OCDatabase` across processes and relaunches
+- can provide a method and query condition on when the policy should automatically be removed (`policyAutoRemovalMethod`, `policyAutoRemovalCondition`)
+
+For convenience, `OCItemPolicy` also offers additional properties to store information for direct usage by Item Policy Processors.
+
+### Item Policy Processor (`OCItemPolicyProcessor`)
+Item Policy Processors (IPP) provide the actual implementation to process the items that match Item Policies of the same kind (`OCItemPolicyKind`) as the Item Policy Processor.
+
+Item Policy Processors can add additional conditions and entry points:
+- `policyCondition`: a query condition matching items that a policy should be run for - in addition to existing Item Policies. Useful to implement IPPs with an - effectively - built-in Item Policy.
+- `matchCondition`: only items passing this query condition are actually processed by the Item Policy Processor.
+- `cleanupCondition`: items matching this query condition are considered to require cleanup after processing and go through the IPP's cleanup.
+
+### Triggers
+Item Policy Processors are run on one or more Triggers:
+
+- `ItemsChanged`: triggered whenever items change (f.ex. following sync actions, PROPFINDs, etc.)
+- `ItemListUpdateCompleted`: triggered whenever an item list update was completed with changes and the database of cache items is considered consistent with server contents
+- `ItemListUpdateCompletedWithoutChanges`: triggered whenever an item list update was completed without changes and the database of cache items is considered consistent with server contents
+- `PoliciesChanged`: triggered whenever an item policy was added, removed or updated
+- `All`: on all of the above Triggers
+
+
+## Call Pattern
+When a trigger is hit in `OCCore`, it goes through the registered Item Policy Processors (IPPs) and makes the following calls:
+- `performPreflightOnPoliciesWithTrigger:withItems:`: allows the IPP to go through (and update) its policies based on the passed items. Items are only passed as they are added, updated or removed. The Available Offline IPP f.ex. uses this to update the paths and locations of its Item Policies as folders are moved or renamed.
+- `willEnterTrigger:`: tells the IPP that the Core will make further calls for the passed Trigger
+- check if `matchCondition` is not `nil` and, if it is not, loops through the trigger's matching items, calling:
+   - `beginMatchingWithTrigger:` before the first item
+   - `performActionOn:withTrigger:` for every matching item. This is typically where an IPP schedules actions.
+   - `endMatchingWithTrigger:` after the last item
+   - none of the above three methdos is called if no items match `matchCondition`
+- check if `cleanupCondition` is not `nil` and, if it is not, loops through the trigger's matching items, calling:
+   - `beginCleanupWithTrigger:` before the first item
+   - `performCleanupOn:withTrigger:` for every matching item. This is typically where an IPP schedules actions.
+   - `endCleanupWithTrigger:` after the last item
+   - none of the above three methdos is called if no items match `cleanupCondition`
+- `didPassTrigger:`: tells the IPP that the Core is finished with it for the passed Trigger

--- a/ownCloudSDK/Core/ItemPolicies/Processors/Available Offline/OCItemPolicyProcessorAvailableOffline.h
+++ b/ownCloudSDK/Core/ItemPolicies/Processors/Available Offline/OCItemPolicyProcessorAvailableOffline.h
@@ -28,4 +28,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 extern OCItemPolicyKind OCItemPolicyKindAvailableOffline; //!< Available Offline: items covered by this policy are pre-downloaded to be available offline.
 
+extern OCSyncReason OCSyncReasonAvailableOffline; //!< Reason for Sync: available offline
+
 NS_ASSUME_NONNULL_END

--- a/ownCloudSDK/Core/ItemPolicies/Processors/Available Offline/OCItemPolicyProcessorAvailableOffline.m
+++ b/ownCloudSDK/Core/ItemPolicies/Processors/Available Offline/OCItemPolicyProcessorAvailableOffline.m
@@ -23,6 +23,10 @@
 #import "OCCore+ItemUpdates.h"
 #import "OCLogger.h"
 #import "OCCellularManager.h"
+#import "OCSyncRecord.h"
+#import "OCCore+SyncEngine.h"
+#import "NSError+OCError.h"
+#import "OCWaitConditionAvailableOffline.h"
 
 @implementation OCItemPolicyProcessorAvailableOffline
 
@@ -187,7 +191,9 @@
 		{
 			[self.core downloadItem:matchingItem options:@{
 				OCCoreOptionDownloadTriggerID : OCItemDownloadTriggerIDAvailableOffline,
-				OCCoreOptionDependsOnCellularSwitch : OCCellularSwitchIdentifierAvailableOffline
+				OCCoreOptionSyncReason : OCSyncReasonAvailableOffline,
+				OCCoreOptionDependsOnCellularSwitch : OCCellularSwitchIdentifierAvailableOffline,
+				OCCoreOptionWaitConditions : @[[OCWaitConditionAvailableOffline new]] // cancels downloads before they start if they are no longer in the AO policy locations
 			} resultHandler:nil];
 		}
 		else if (matchingItem.cloudStatus == OCItemCloudStatusLocalCopy)
@@ -238,3 +244,4 @@
 @end
 
 OCItemPolicyKind OCItemPolicyKindAvailableOffline = @"availableOffline";
+OCSyncReason OCSyncReasonAvailableOffline = @"availableOffline";

--- a/ownCloudSDK/Core/ItemPolicies/Processors/OCItemPolicyProcessor.h
+++ b/ownCloudSDK/Core/ItemPolicies/Processors/OCItemPolicyProcessor.h
@@ -29,6 +29,7 @@ typedef NS_OPTIONS(NSUInteger, OCItemPolicyProcessorTrigger)
 	OCItemPolicyProcessorTriggerItemListUpdateCompleted = (1<<1),	//!< Triggered whenever an item list update was completed with changes and the database of cache items is considered consistent with server contents
 	OCItemPolicyProcessorTriggerItemListUpdateCompletedWithoutChanges = (1<<2),	//!< Triggered whenever an item list update was completed without changes and the database of cache items is considered consistent with server contents
 	OCItemPolicyProcessorTriggerPoliciesChanged = (1<<3),		//!< Triggered whenever an item policy was added, removed or updated
+	OCItemPolicyProcessorTriggerSyncReason = (1<<4),		//!< Triggered whenever the amount of actions with the provided Sync Reason has changed and is below maximumActiveSyncActions.
 
 	OCItemPolicyProcessorTriggerAll = NSUIntegerMax
 };
@@ -52,6 +53,13 @@ typedef NS_OPTIONS(NSUInteger, OCItemPolicyProcessorTrigger)
 
 @property(nullable,strong) NSString *localizedName; //!< Localized name of the policy
 @property(nullable,strong,nonatomic) OCQueryCondition *customQueryCondition;	//!< Query condition that can be used to present items matched by the policy (typically equals .matchCondition). nil if it shouldn't.
+
+@property(nullable,strong) OCSyncReason syncReason; //!< The Sync Reason that Sync Actions started from this policy use. If there's no longer any action with this Sync Reason;
+@property(nullable,strong) NSNumber *maximumActiveSyncActions; //!< The maximum number of Sync Actions
+@property(nullable,strong) NSNumber *maximumQueriedItems; //!< Limits queries into the database to .maximumQueriedItems in advance. Should only be used if -performActionOn: ALWAYS schedules an action in the Sync Engine. Otherwise, the active Sync Action count for the Sync Reason will not change - and the Policy Processor not be triggered again. Also, the Policy Processor may be fed with the same items that do not trigger any Sync Action again, effectively preventing the necessary handling to take place.
+
+@property(assign) BOOL hasPendingActionItems; //!< Internal, tracks if there are (possibly) pending items if .syncReason != nil, maximumActiveSyncActions != nil AND the number of active sync actions with this Sync Reason is less than .maximumActiveSyncActions
+@property(nullable,strong) NSNumber *activeSyncActionCount; //!< Internal, if .syncReason != nil, tracks the number of active sync actions with that Sync Reason
 
 - (instancetype)initWithKind:(OCItemPolicyKind)kind core:(OCCore *)core;
 

--- a/ownCloudSDK/Core/OCCore.h
+++ b/ownCloudSDK/Core/OCCore.h
@@ -122,6 +122,7 @@ typedef void(^OCCoreItemPoliciesCompletionHandler)(NSError * _Nullable error, NS
 typedef void(^OCCoreClaimCompletionHandler)(NSError * _Nullable error, OCItem * _Nullable item);
 typedef void(^OCCoreCompletionHandler)(NSError * _Nullable error);
 typedef void(^OCCoreStateChangedHandler)(OCCore *core);
+typedef void(^OCCoreSyncReasonCountChangeObserver)(OCCore *core, BOOL initial, NSDictionary<OCSyncReason, NSNumber *> * _Nullable countBySyncReason);
 
 typedef void(^OCCoreBusyStatusHandler)(NSProgress * _Nullable progress);
 
@@ -288,6 +289,9 @@ typedef id<NSObject> OCCoreItemTracking;
 	OCQuery *_availableOfflineFilesQuery;
 	BOOL _availableOfflineFilesDataSourceHasSubscribers;
 	OCDataSourceComposition *_availableOfflineFilesDataSource;
+
+	NSMutableArray<OCCoreSyncReasonCountChangeObserver> *_syncReasonCountChangeObservers;
+	NSDictionary<OCSyncReason, NSNumber *> *_lastSyncReasonCounts;
 
 	__weak id <OCCoreDelegate> _delegate;
 

--- a/ownCloudSDK/Core/OCCore.h
+++ b/ownCloudSDK/Core/OCCore.h
@@ -531,6 +531,7 @@ extern OCCoreOption OCCoreOptionReturnImmediatelyIfOfflineOrUnavailable; //!< [B
 extern OCCoreOption OCCoreOptionPlaceholderCompletionHandler; //!< [OCCorePlaceholderCompletionHandler] For actions that support it: optional block that's invoked with the placeholder item if one is created by the action.
 extern OCCoreOption OCCoreOptionAutomaticConflictResolutionNameStyle; //!< [OCCoreDuplicateNameStyleNone] Automatically resolves conflicts while performing the action. For import, that means automatic rename of the file to upload if a file with the same name already exists, using the provided naming style.
 extern OCCoreOption OCCoreOptionDownloadTriggerID; //!< [OCItemDownloadTriggerID] An ID of what triggered the download (f.ex. "AvailableOffline" or "User")
+extern OCCoreOption OCCoreOptionSyncReason; //!< [OCCoreOptionSyncReason] The reason the sync action was triggered. Becomes available on the OCSyncRecord.syncReason level.
 extern OCCoreOption OCCoreOptionAddFileClaim; //!< [OCClaim] A claim to add to an item as part of an action (typically upload/download)
 extern OCCoreOption OCCoreOptionAddTemporaryClaimForPurpose; //!< [OCCoreClaimPurpose] Adds a temporary claim to the returned OCFile object (download) generated for the provided purpose. Makes sure the claim is automatically removed if the OCCore is still running when the object is deallocated. (default is OCCoreClaimPurposeNone)
 extern OCCoreOption OCCoreOptionSkipRedundancyChecks; //!< [BOOL] Determines whether AvailableOffline should skip redundancy checks.
@@ -539,6 +540,8 @@ extern OCCoreOption OCCoreOptionLastModifiedDate; //!< [NSDate] For uploads, the
 extern OCCoreOption OCCoreOptionDependsOnCellularSwitch; //!< [OCCellularSwitchIdentifier] Tells the core to set the permission for cellular access according to the status of the provided OCCellularSwitchIdentifier (currently only supported for up- and downloads).
 
 extern OCKeyValueStoreKey OCCoreSkipAvailableOfflineKey; //!< Vault.KVS-key with a NSNumber Boolean value. If the value is YES, available offline item policies are skipped.
+
+extern OCSyncReason OCSyncReasonUserInteraction; //!< Sync Action was triggered by a user interaction;
 
 extern NSNotificationName OCCoreItemBeginsHavingProgress; //!< Notification sent when an item starts having progress. The object is the localID of the item.
 extern NSNotificationName OCCoreItemChangedProgress; //!< Notification sent when an item's progress changed. The object is the localID of the item.

--- a/ownCloudSDK/Core/OCCore.h
+++ b/ownCloudSDK/Core/OCCore.h
@@ -538,6 +538,7 @@ extern OCCoreOption OCCoreOptionSkipRedundancyChecks; //!< [BOOL] Determines whe
 extern OCCoreOption OCCoreOptionConvertExistingLocalDownloads; //!< [BOOL] Determines whether AvailableOffline should convert existing local copies to Available Offline managed items if they fall under a new Available Offline rule
 extern OCCoreOption OCCoreOptionLastModifiedDate; //!< [NSDate] For uploads, the date that should be used as last modified date for the uploaded file.
 extern OCCoreOption OCCoreOptionDependsOnCellularSwitch; //!< [OCCellularSwitchIdentifier] Tells the core to set the permission for cellular access according to the status of the provided OCCellularSwitchIdentifier (currently only supported for up- and downloads).
+extern OCCoreOption OCCoreOptionWaitConditions; //!< [OCWaitCondition] Wait conditions that must be met before the sync record should be scheduled.
 
 extern OCKeyValueStoreKey OCCoreSkipAvailableOfflineKey; //!< Vault.KVS-key with a NSNumber Boolean value. If the value is YES, available offline item policies are skipped.
 

--- a/ownCloudSDK/Core/OCCore.m
+++ b/ownCloudSDK/Core/OCCore.m
@@ -2560,6 +2560,7 @@ OCCoreOption OCCoreOptionReturnImmediatelyIfOfflineOrUnavailable = @"returnImmed
 OCCoreOption OCCoreOptionPlaceholderCompletionHandler = @"placeHolderCompletionHandler";
 OCCoreOption OCCoreOptionAutomaticConflictResolutionNameStyle = @"automaticConflictResolutionNameStyle";
 OCCoreOption OCCoreOptionDownloadTriggerID = @"downloadTriggerID";
+OCCoreOption OCCoreOptionSyncReason = @"syncReason";
 OCCoreOption OCCoreOptionAddFileClaim = @"addFileClaim";
 OCCoreOption OCCoreOptionAddTemporaryClaimForPurpose = @"addTemporaryClaimForPurpose";
 OCCoreOption OCCoreOptionSkipRedundancyChecks = @"skipRedundancyChecks";
@@ -2568,6 +2569,8 @@ OCCoreOption OCCoreOptionLastModifiedDate = @"lastModifiedDate";
 OCCoreOption OCCoreOptionDependsOnCellularSwitch = @"dependsOnCellularSwitch";
 
 OCKeyValueStoreKey OCCoreSkipAvailableOfflineKey = @"core.skip-available-offline";
+
+OCSyncReason OCSyncReasonUserInteraction = @"userInteraction";
 
 NSNotificationName OCCoreItemBeginsHavingProgress = @"OCCoreItemBeginsHavingProgress";
 NSNotificationName OCCoreItemChangedProgress = @"OCCoreItemChangedProgress";

--- a/ownCloudSDK/Core/OCCore.m
+++ b/ownCloudSDK/Core/OCCore.m
@@ -290,6 +290,8 @@ INCLUDE_IN_CLASS_SETTINGS_SNAPSHOTS(OCCore)
 
 		_fetchUpdatesCompletionHandlers = [NSMutableArray new];
 
+		_syncReasonCountChangeObservers = [NSMutableArray new];
+
 		_progressByLocalID = [NSMutableDictionary new];
 
 		_drives = [NSMutableArray new];

--- a/ownCloudSDK/Core/OCCore.m
+++ b/ownCloudSDK/Core/OCCore.m
@@ -2567,6 +2567,7 @@ OCCoreOption OCCoreOptionSkipRedundancyChecks = @"skipRedundancyChecks";
 OCCoreOption OCCoreOptionConvertExistingLocalDownloads = @"convertExistingLocalDownloads";
 OCCoreOption OCCoreOptionLastModifiedDate = @"lastModifiedDate";
 OCCoreOption OCCoreOptionDependsOnCellularSwitch = @"dependsOnCellularSwitch";
+OCCoreOption OCCoreOptionWaitConditions = @"waitConditions";
 
 OCKeyValueStoreKey OCCoreSkipAvailableOfflineKey = @"core.skip-available-offline";
 

--- a/ownCloudSDK/Core/Sync/Actions/Download/OCSyncActionDownload.h
+++ b/ownCloudSDK/Core/Sync/Actions/Download/OCSyncActionDownload.h
@@ -18,9 +18,8 @@
 
 #import "OCSyncAction.h"
 
-@interface OCSyncActionDownload : OCSyncAction
+@interface OCSyncActionDownload : OCSyncAction <OCSyncActionOptions>
 
-@property(strong) NSDictionary<OCCoreOption,id> *options;
 @property(assign) NSUInteger resolutionRetries;
 
 - (instancetype)initWithItem:(OCItem *)item options:(NSDictionary<OCCoreOption,id> *)options;

--- a/ownCloudSDK/Core/Sync/Actions/Download/OCSyncActionDownload.m
+++ b/ownCloudSDK/Core/Sync/Actions/Download/OCSyncActionDownload.m
@@ -30,6 +30,8 @@ static OCMessageTemplateIdentifier OCMessageTemplateIdentifierDownloadCancel = @
 
 @implementation OCSyncActionDownload
 
+@synthesize options;
+
 OCSYNCACTION_REGISTER_ISSUETEMPLATES
 
 + (OCSyncActionIdentifier)identifier
@@ -786,13 +788,13 @@ OCSYNCACTION_REGISTER_ISSUETEMPLATES
 #pragma mark - NSCoding
 - (void)decodeActionData:(NSCoder *)decoder
 {
-	_options = [decoder decodeObjectOfClasses:OCEvent.safeClasses forKey:@"options"];
+	self.options = [decoder decodeObjectOfClasses:OCEvent.safeClasses forKey:@"options"];
 	_resolutionRetries = (NSUInteger)[decoder decodeIntForKey:@"resolutionRetries"];
 }
 
 - (void)encodeActionData:(NSCoder *)coder
 {
-	[coder encodeObject:_options forKey:@"options"];
+	[coder encodeObject:self.options forKey:@"options"];
 	[coder encodeInteger:_resolutionRetries forKey:@"resolutionRetries"];
 }
 

--- a/ownCloudSDK/Core/Sync/Actions/Download/OCSyncActionDownload.m
+++ b/ownCloudSDK/Core/Sync/Actions/Download/OCSyncActionDownload.m
@@ -72,6 +72,7 @@ OCSYNCACTION_REGISTER_ISSUETEMPLATES
 	if ((self = [super initWithItem:item]) != nil)
 	{
 		self.options = options;
+		self.syncReason = options[OCCoreOptionSyncReason];
 
 		self.actionEventType = OCEventTypeDownload;
 		self.localizedDescription = [NSString stringWithFormat:OCLocalized(@"Downloading %@…"), item.name];

--- a/ownCloudSDK/Core/Sync/Actions/OCSyncAction.h
+++ b/ownCloudSDK/Core/Sync/Actions/OCSyncAction.h
@@ -46,6 +46,10 @@ typedef NS_ENUM(NSUInteger, OCCoreSyncInstruction)
 	OCCoreSyncInstructionProcessNext	//!< Process next
 };
 
+@protocol OCSyncActionOptions <NSObject>
+@property(strong,nullable) NSDictionary<OCCoreOption,id> *options;
+@end
+
 @interface OCSyncAction : NSObject <NSSecureCoding, OCLogTagging, OCLogPrivacyMasking>
 {
 	OCItem *_archivedServerItem;

--- a/ownCloudSDK/Core/Sync/Actions/OCSyncAction.h
+++ b/ownCloudSDK/Core/Sync/Actions/OCSyncAction.h
@@ -62,6 +62,7 @@ typedef NS_ENUM(NSUInteger, OCCoreSyncInstruction)
 
 #pragma mark - Persisted properties
 @property(strong,nullable) OCActionTrackingID actionTrackingID; //!< Action tracking ID used to identify requests, responses and events belonging to this action.
+@property(strong,nullable) OCSyncReason syncReason; //!< Reason this action is being run.
 
 @property(strong) OCItem *localItem; //!< Locally managed OCItem that this action is performed on (persisted)
 @property(readonly,nonatomic,nullable) OCItem *latestVersionOfLocalItem; //!< The latest version of the item, retrieved from the database

--- a/ownCloudSDK/Core/Sync/Actions/OCSyncAction.m
+++ b/ownCloudSDK/Core/Sync/Actions/OCSyncAction.m
@@ -373,6 +373,7 @@
 	[coder encodeObject:_categories forKey:@"categories"];
 
 	[coder encodeObject:_actionTrackingID forKey:@"trackingID"];
+	[coder encodeObject:_syncReason forKey:@"syncReason"];
 
 	[self encodeActionData:coder];
 }
@@ -395,6 +396,7 @@
 		_categories = [decoder decodeObjectOfClasses:[[NSSet alloc] initWithObjects:[NSArray class], [NSString class], nil] forKey:@"categories"];
 
 		_actionTrackingID = [decoder decodeObjectOfClass:NSString.class forKey:@"trackingID"];
+		_syncReason = [decoder decodeObjectOfClass:NSString.class forKey:@"syncReason"];
 
 		[self decodeActionData:decoder];
 	}

--- a/ownCloudSDK/Core/Sync/Actions/Upload/OCSyncActionUpload.h
+++ b/ownCloudSDK/Core/Sync/Actions/Upload/OCSyncActionUpload.h
@@ -18,7 +18,7 @@
 
 #import "OCSyncAction.h"
 
-@interface OCSyncActionUpload : OCSyncAction
+@interface OCSyncActionUpload : OCSyncAction <OCSyncActionOptions>
 
 @property(strong) OCItem *parentItem;
 
@@ -31,8 +31,6 @@
 @property(strong) NSString *filename;
 
 @property(strong) NSURL *uploadCopyFileURL; //!< COW-clone of the file to import, made just before upload, so the file *can* be updated while uploading
-
-@property(strong) NSDictionary<OCCoreOption,id> *options;
 
 - (instancetype)initWithUploadItem:(OCItem *)uploadItem parentItem:(OCItem *)parentItem filename:(NSString *)filename importFileURL:(NSURL *)importFileURL isTemporaryCopy:(BOOL)isTemporaryCopy options:(NSDictionary<OCCoreOption,id> *)options;
 

--- a/ownCloudSDK/Core/Sync/Actions/Upload/OCSyncActionUpload.m
+++ b/ownCloudSDK/Core/Sync/Actions/Upload/OCSyncActionUpload.m
@@ -69,6 +69,7 @@ OCSYNCACTION_REGISTER_ISSUETEMPLATES
 		self.localizedDescription = [NSString stringWithFormat:OCLocalized(@"Uploading %@…"), ((filename!=nil) ? filename : uploadItem.name)];
 
 		self.options = options;
+		self.syncReason = options[OCCoreOptionSyncReason];
 
 		self.categories = @[
 			OCSyncActionCategoryAll, OCSyncActionCategoryTransfer,

--- a/ownCloudSDK/Core/Sync/Actions/Upload/OCSyncActionUpload.m
+++ b/ownCloudSDK/Core/Sync/Actions/Upload/OCSyncActionUpload.m
@@ -29,6 +29,8 @@ static OCMessageTemplateIdentifier OCMessageTemplateIdentifierUploadRetry = @"up
 
 @implementation OCSyncActionUpload
 
+@synthesize options;
+
 OCSYNCACTION_REGISTER_ISSUETEMPLATES
 
 + (OCSyncActionIdentifier)identifier
@@ -502,7 +504,7 @@ OCSYNCACTION_REGISTER_ISSUETEMPLATES
 		if ([choice.identifier isEqual:@"replaceExisting"])
 		{
 			// Replace existing (force replace)
-			NSMutableDictionary<OCCoreOption,id> *options = (_options != nil) ? [_options mutableCopy] : [NSMutableDictionary new];
+			NSMutableDictionary<OCCoreOption,id> *options = (self.options != nil) ? [self.options mutableCopy] : [NSMutableDictionary new];
 			options[OCConnectionOptionForceReplaceKey] = @(YES);
 			self.options = options;
 
@@ -546,7 +548,7 @@ OCSYNCACTION_REGISTER_ISSUETEMPLATES
 
 	_uploadCopyFileURL = [decoder decodeObjectOfClass:[NSURL class] forKey:@"uploadCopyFileURL"];
 
-	_options = [decoder decodeObjectOfClasses:OCEvent.safeClasses forKey:@"options"];
+	self.options = [decoder decodeObjectOfClasses:OCEvent.safeClasses forKey:@"options"];
 }
 
 - (void)encodeActionData:(NSCoder *)coder
@@ -562,7 +564,7 @@ OCSYNCACTION_REGISTER_ISSUETEMPLATES
 
 	[coder encodeObject:_uploadCopyFileURL forKey:@"uploadCopyFileURL"];
 
-	[coder encodeObject:_options forKey:@"options"];
+	[coder encodeObject:self.options forKey:@"options"];
 }
 
 @end

--- a/ownCloudSDK/Core/Sync/OCCore+SyncEngine.h
+++ b/ownCloudSDK/Core/Sync/OCCore+SyncEngine.h
@@ -55,6 +55,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)rescheduleSyncRecord:(OCSyncRecord *)syncRecord withUpdates:(NSError * _Nullable (^ _Nullable)(OCSyncRecord *record))applyUpdates;
 - (void)descheduleSyncRecord:(OCSyncRecord *)syncRecord completeWithError:(nullable NSError *)completionError parameter:(nullable id)parameter;
 
+#pragma mark - Sync Action Scheduling Flow Control
+- (void)addSyncReasonCountChangeObserver:(OCCoreSyncReasonCountChangeObserver)changeObserver forSyncReason:(nullable OCSyncReason)syncReason withInitial:(BOOL)withInitial;
+
 @end
 
 @interface OCCore (SyncPrivate)

--- a/ownCloudSDK/Core/Sync/Record/OCSyncRecord.h
+++ b/ownCloudSDK/Core/Sync/Record/OCSyncRecord.h
@@ -82,6 +82,7 @@ typedef NS_ENUM(NSInteger, OCSyncRecordState)
 @property(readonly,nonatomic) OCSyncRecordState state; //!< Current processing state
 
 @property(strong,nullable) NSDate *inProgressSince; //!< Time since which the action is being executed
+@property(strong,nullable) OCSyncReason syncReason; //!< (optional) reason the action managed by this sync record has been started
 
 @property(strong,nullable) NSArray <OCWaitCondition *> *waitConditions; //!< If state==OCSyncRecordStateProcessing, the conditions that need to be fulfilled before proceeding.
 

--- a/ownCloudSDK/Core/Sync/Record/OCSyncRecord.m
+++ b/ownCloudSDK/Core/Sync/Record/OCSyncRecord.m
@@ -56,6 +56,8 @@
 
 		_resultSignalUUID = resultSignalUUID;
 		_progressSignalUUID = OCSignal.generateUUID;
+
+		_syncReason = action.syncReason;
 	}
 
 	return (self);
@@ -221,25 +223,26 @@
 {
 	if ((self = [self init]) != nil)
 	{
-		_recordID = [decoder decodeObjectOfClass:[NSNumber class] forKey:@"recordID"];
+		_recordID = [decoder decodeObjectOfClass:NSNumber.class forKey:@"recordID"];
 
-		_laneID = [decoder decodeObjectOfClass:[NSNumber class] forKey:@"laneID"];
+		_laneID = [decoder decodeObjectOfClass:NSNumber.class forKey:@"laneID"];
 
-		_originProcessSession = [decoder decodeObjectOfClass:[OCProcessSession class] forKey:@"originProcessSession"];
+		_originProcessSession = [decoder decodeObjectOfClass:OCProcessSession.class forKey:@"originProcessSession"];
 
-		_actionIdentifier = [decoder decodeObjectOfClass:[NSString class] forKey:@"actionID"];
-		_action = [decoder decodeObjectOfClass:[OCSyncRecord class] forKey:@"action"];
+		_actionIdentifier = [decoder decodeObjectOfClass:NSString.class forKey:@"actionID"];
+		_action = [decoder decodeObjectOfClass:OCSyncRecord.class forKey:@"action"];
 
 		_timestamp = [decoder decodeObjectOfClass:[NSDate class] forKey:@"timestamp"];
 
 		_state = (OCSyncRecordState)[decoder decodeIntegerForKey:@"state"];
-		_inProgressSince = [decoder decodeObjectOfClass:[NSDate class] forKey:@"inProgressSince"];
+		_inProgressSince = [decoder decodeObjectOfClass:NSDate.class forKey:@"inProgressSince"];
+		_syncReason = [decoder decodeObjectOfClass:NSString.class forKey:@"syncReason"];
 
 		_resultSignalUUID = [decoder decodeObjectOfClass:NSString.class forKey:@"resultSignalUUID"];
 		_progressSignalUUID = [decoder decodeObjectOfClass:NSString.class forKey:@"progressSignalUUID"];
 
 		_isProcessIndependent = [decoder decodeBoolForKey:@"isProcessIndependent"];
-		_progress = [decoder decodeObjectOfClass:[OCProgress class] forKey:@"progress"];
+		_progress = [decoder decodeObjectOfClass:OCProgress.class forKey:@"progress"];
 
 		_waitConditions = [decoder decodeObjectOfClasses:[[NSSet alloc] initWithObjects:NSArray.class, OCWaitCondition.class, nil] forKey:@"waitConditions"];
 	}
@@ -262,6 +265,7 @@
 
 	[coder encodeInteger:(NSInteger)_state forKey:@"state"];
 	[coder encodeObject:_inProgressSince forKey:@"inProgressSince"];
+	[coder encodeObject:_syncReason forKey:@"syncReason"];
 
 	[coder encodeObject:_resultSignalUUID forKey:@"resultSignalUUID"];
 

--- a/ownCloudSDK/OCTypes.h
+++ b/ownCloudSDK/OCTypes.h
@@ -59,6 +59,8 @@ typedef NSString* OCSyncActionCategory NS_TYPED_ENUM;
 typedef NSNumber* OCSyncRecordID;
 typedef NSNumber* OCSyncRecordRevision;
 
+typedef NSString* OCSyncReason NS_TYPED_ENUM; //!< Reason a sync action has been started (f.ex. user, available offline, ..)
+
 typedef NSNumber* OCSyncLaneID;
 typedef NSString* OCSyncLaneTag;
 

--- a/ownCloudSDK/Vaults/Database/OCDatabase+Schemas.m
+++ b/ownCloudSDK/Vaults/Database/OCDatabase+Schemas.m
@@ -1265,6 +1265,82 @@
 			}]];
 		}]
 	];
+
+	// Version 19
+	/*
+		Mark dangling items as removed. Dangling items are items without an existing parent folder.
+		The schema itself remains UNCHANGED.
+	*/
+	[self.sqlDB addTableSchema:[OCSQLiteTableSchema
+		schemaWithTableName:OCDatabaseTableNameMetaData
+		version:19
+		creationQueries:@[
+			/*
+				mdID : INTEGER	  		- unique ID used to uniquely identify and efficiently update a row
+				type : INTEGER    		- OCItemType value to indicate if this is a file or a collection/folder
+				syncAnchor: INTEGER		- sync anchor, a number that increases its value with every change to an entry. For files, higher sync anchor values indicate the file changed (incl. creation, content or meta data changes). For collections/folders, higher sync anchor values indicate the list of items in the collection/folder changed in a way not covered by file entries (i.e. rename, deletion, but not creation of files).
+				removed : INTEGER		- value indicating if this file or folder has been removed: 1 if it was, 0 if not (default). Removed entries are kept around until their delta to the latest syncAnchor value exceeds -[OCDatabase removedItemRetentionLength].
+				mdTimestamp: INTEGER		- NSDate.timeIntervalSinceReferenceDate value of creation or last update of this record
+				locallyModified: INTEGER	- value indicating if this is a file that's been created or modified locally
+				localRelativePath: TEXT		- path of the local copy of the item, relative to the rootURL of the vault that stores it
+				locationString : TEXT		- OCLocation.string, built from driveID + path, can be used to find all items inside a folder on a drive
+				path : TEXT	  		- full path of the item (e.g. "/example/file.txt")
+				parentPath : TEXT 		- parent path of the item. (e.g. "/example" for an item at "/example/file.txt")
+				name : TEXT 	  		- name of the item (e.g. "file.txt" for an item at "/example/file.txt")
+				mimeType : TEXT			- MIME type of the item (OCMIMEType)
+				typeAlias : TEXT		- Type alias of the item (OCTypeAlias)
+				size : INTEGER			- size of the item
+				favorite : INTEGER		- BOOL indicating if the item is favorite (OCItem.isFavorite)
+				cloudStatus : INTEGER 		- Cloud status of the item (OCItem.cloudStatus)
+				downloadTrigger : TEXT		- What triggered the download of the item (OCItemDownloadTriggerID)
+				hasLocalAttributes : INTEGER 	- BOOL indicating an item with local attributes (OCItem.hasLocalAttributes)
+				lastUsedDate : REAL 		- NSDate.timeIntervalSince1970 value of OCItem.lastUsed
+				lastModifiedDate : REAL		- NSDate.timeIntervalSince1970 value of OCItem.lastModified
+				syncActivity : INTEGER 		- OCSyncActivity mask indicating which sync activity the item has (0 for none) (OCItem.syncActivity)
+				ownerUserName : TEXT		- User name of the owner of this item (OCItem.user.userName)
+				driveID : TEXT			- OCDriveID identifying the drive the item is located on
+				fileID : TEXT			- OCFileID identifying the item
+				localID : TEXT			- OCLocalID identifying the item
+				itemData : BLOB	  		- data of the serialized OCItem
+			*/
+			@"CREATE TABLE metaData (mdID INTEGER PRIMARY KEY AUTOINCREMENT, type INTEGER NOT NULL, syncAnchor INTEGER NOT NULL, removed INTEGER NOT NULL, mdTimestamp INTEGER NOT NULL, locallyModified INTEGER NOT NULL, localRelativePath TEXT NULL, locationString TEXT NOT NULL, path TEXT NOT NULL, parentPath TEXT NOT NULL, name TEXT NOT NULL COLLATE OCLOCALIZED, mimeType TEXT NULL, typeAlias TEXT NULL, size INTEGER NOT NULL, favorite INTEGER NOT NULL, cloudStatus INTEGER NOT NULL, downloadTrigger TEXT NULL, hasLocalAttributes INTEGER NOT NULL, lastUsedDate REAL NULL, lastModifiedDate REAL NULL, syncActivity INTEGER NULL, ownerUserName TEXT, driveID TEXT, fileID TEXT, localID TEXT, itemData BLOB NOT NULL)",
+
+			// Create indexes over path and parentPath
+			@"CREATE INDEX idx_metaData_locationString ON metaData (locationString)",
+			@"CREATE INDEX idx_metaData_path ON metaData (path)",
+			@"CREATE INDEX idx_metaData_parentPath ON metaData (parentPath)",
+			@"CREATE INDEX idx_metaData_synchAnchor ON metaData (syncAnchor)",
+			@"CREATE INDEX idx_metaData_localID ON metaData (localID)",
+			@"CREATE INDEX idx_metaData_driveID ON metaData (driveID)",
+			@"CREATE INDEX idx_metaData_fileID ON metaData (fileID)",
+			@"CREATE INDEX idx_metaData_typeAlias ON metaData (typeAlias)",
+			@"CREATE INDEX idx_metaData_removed ON metaData (removed)",
+			@"CREATE INDEX idx_metaData_downloadTrigger ON metaData (downloadTrigger)",
+			@"CREATE INDEX idx_metaData_cloudStatus ON metaData (cloudStatus)",
+		]
+		openStatements:@[
+			// Create trigger to delete thumbnails alongside metadata entries
+			@"CREATE TEMPORARY TRIGGER temp_delete_associated_thumbnails AFTER DELETE ON metaData BEGIN DELETE FROM thumb.thumbnails WHERE fileID = OLD.fileID; END" // relatedTo:OCDatabaseTableNameThumbnails
+		]
+		upgradeMigrator:^(OCSQLiteDB *db, OCSQLiteTableSchema *schema, void (^completionHandler)(NSError *error)) {
+			// Migrate to version 19
+			[db executeTransaction:[OCSQLiteTransaction transactionWithBlock:^NSError *(OCSQLiteDB *db, OCSQLiteTransaction *transaction) {
+				INSTALL_TRANSACTION_ERROR_COLLECTION_RESULT_HANDLER
+
+				// Create "downloadTrigger" index
+				[db executeQuery:[OCSQLiteQuery query:@"CREATE INDEX idx_metaData_downloadTrigger ON metaData (downloadTrigger)" resultHandler:resultHandler]];
+				if (transactionError != nil) { return(transactionError); }
+
+				// Create "cloudStatus" index
+				[db executeQuery:[OCSQLiteQuery query:@"CREATE INDEX idx_metaData_cloudStatus ON metaData (cloudStatus)" resultHandler:resultHandler]];
+				if (transactionError != nil) { return(transactionError); }
+
+				return (transactionError);
+			} type:OCSQLiteTransactionTypeDeferred completionHandler:^(OCSQLiteDB *db, OCSQLiteTransaction *transaction, NSError *error) {
+				completionHandler(error);
+			}]];
+		}]
+	];
 }
 
 - (void)addOrUpdateSyncLanesSchema
@@ -1504,12 +1580,58 @@
 		]
 		openStatements:nil
 		upgradeMigrator:^(OCSQLiteDB *db, OCSQLiteTableSchema *schema, void (^completionHandler)(NSError *error)) {
-			// Migrate to version 5
+			// Migrate to version 6
 			[db executeTransaction:[OCSQLiteTransaction transactionWithBlock:^NSError *(OCSQLiteDB *sqlDB, OCSQLiteTransaction *transaction) {
 				INSTALL_TRANSACTION_ERROR_COLLECTION_RESULT_HANDLER
 
 				// Add revision column
 				[sqlDB executeQuery:[OCSQLiteQuery query:@"ALTER TABLE syncJournal ADD COLUMN revision INTEGER" resultHandler:resultHandler]];
+				if (transactionError != nil) { return(transactionError); }
+
+				return (transactionError);
+			} type:OCSQLiteTransactionTypeDeferred completionHandler:^(OCSQLiteDB *db, OCSQLiteTransaction *transaction, NSError *error) {
+				completionHandler(error);
+			}]];
+		}]
+	];
+
+	// Version 7
+	[self.sqlDB addTableSchema:[OCSQLiteTableSchema
+		schemaWithTableName:OCDatabaseTableNameSyncJournal
+		version:7
+		creationQueries:@[
+			/*
+				recordID : INTEGER  		- unique ID used to uniquely identify and efficiently update a row
+				laneID : INTEGER		- ID of the sync lane this record is scheduled on
+				revision : INTEGER		- revision of the record, increments with every update
+				timestampDate : REAL		- NSDate.timeIntervalSince1970 at the time the record was added to the journal
+				inProgressSinceDate : REAL	- NSDate.timeIntervalSince1970 at the time the record was beginning to be processed
+				action : TEXT			- action to perform
+				localID : TEXT			- localID of the item targeted by the operation
+				path : TEXT			- path of the item targeted by the operation
+				syncReason : TEXT		- reason the sync action was scheduled (see OCSyncReason)
+				recordData : BLOB		- archived OCSyncRecord data
+			*/
+			@"CREATE TABLE syncJournal (recordID INTEGER PRIMARY KEY AUTOINCREMENT, laneID INTEGER, revision INTEGER, timestampDate REAL NOT NULL, inProgressSinceDate REAL, action TEXT NOT NULL, localID TEXT NOT NULL, path TEXT NOT NULL, syncReason TEXT, recordData BLOB)",
+
+			@"CREATE INDEX idx_syncJournal_laneID ON syncJournal (laneID)",
+			@"CREATE INDEX idx_syncJournal_syncReason ON syncJournal (syncReason)"
+		]
+		openStatements:nil
+		upgradeMigrator:^(OCSQLiteDB *db, OCSQLiteTableSchema *schema, void (^completionHandler)(NSError *error)) {
+			// Migrate to version 7
+			[db executeTransaction:[OCSQLiteTransaction transactionWithBlock:^NSError *(OCSQLiteDB *sqlDB, OCSQLiteTransaction *transaction) {
+				INSTALL_TRANSACTION_ERROR_COLLECTION_RESULT_HANDLER
+
+				// Add syncReason column
+				[sqlDB executeQuery:[OCSQLiteQuery query:@"ALTER TABLE syncJournal ADD COLUMN syncReason TEXT" resultHandler:resultHandler]];
+				if (transactionError != nil) { return(transactionError); }
+
+				// Add new indices
+				[sqlDB executeQuery:[OCSQLiteQuery query:@"CREATE INDEX idx_syncJournal_laneID ON syncJournal (laneID)" resultHandler:resultHandler]];
+				if (transactionError != nil) { return(transactionError); }
+
+				[sqlDB executeQuery:[OCSQLiteQuery query:@"CREATE INDEX idx_syncJournal_syncReason ON syncJournal (syncReason)" resultHandler:resultHandler]];
 				if (transactionError != nil) { return(transactionError); }
 
 				return (transactionError);

--- a/ownCloudSDK/Vaults/Database/OCDatabase.h
+++ b/ownCloudSDK/Vaults/Database/OCDatabase.h
@@ -50,6 +50,7 @@ typedef void(^OCDatabaseRetrieveSyncRecordCountCompletionHandler)(OCDatabase *db
 typedef void(^OCDatabaseRetrieveSyncRecordIDsCompletionHandler)(OCDatabase *db, NSError *error, NSSet<OCSyncRecordID> *syncRecordIDs);
 typedef void(^OCDatabaseRetrieveSyncLaneCompletionHandler)(OCDatabase *db, NSError *error, OCSyncLane *syncRecord);
 typedef void(^OCDatabaseRetrieveSyncLanesCompletionHandler)(OCDatabase *db, NSError *error, NSArray <OCSyncLane *> *syncLanes);
+typedef void(^OCDatabaseRetrieveSyncReasonCountsCompletionHandler)(OCDatabase *db, NSError *error, NSDictionary<OCSyncReason, NSNumber *> *syncReasonCounts);
 typedef void(^OCDatabaseDirectoryUpdateJobCompletionHandler)(OCDatabase *db, NSError *error, OCCoreDirectoryUpdateJob *updateJob);
 typedef void(^OCDatabaseRetrieveDirectoryUpdateJobsCompletionHandler)(OCDatabase *db, NSError *error, NSArray<OCCoreDirectoryUpdateJob *> *updateJobs);
 typedef void(^OCDatabaseProtectedBlockCompletionHandler)(NSError *error, NSNumber *previousCounterValue, NSNumber *newCounterValue);
@@ -155,6 +156,7 @@ typedef NSString* OCDatabaseCounterIdentifier;
 - (void)retrieveSyncRecordForID:(OCSyncRecordID)recordID completionHandler:(OCDatabaseRetrieveSyncRecordCompletionHandler)completionHandler;
 - (void)retrieveSyncRecordAfterID:(OCSyncRecordID)recordID onLaneID:(OCSyncLaneID)laneID completionHandler:(OCDatabaseRetrieveSyncRecordCompletionHandler)completionHandler;
 - (void)retrieveSyncRecordsForPath:(OCPath)path action:(OCSyncActionIdentifier)action inProgressSince:(NSDate *)inProgressSince completionHandler:(OCDatabaseRetrieveSyncRecordsCompletionHandler)completionHandler;
+- (void)retrieveSyncReasonCountsWithCompletionHandler:(OCDatabaseRetrieveSyncReasonCountsCompletionHandler)completionHandler;
 
 #pragma mark - Event interface
 - (void)queueEvent:(OCEvent *)event forSyncRecordID:(OCSyncRecordID)syncRecordID processSession:(OCProcessSession *)processSession completionHandler:(OCDatabaseCompletionHandler)completionHandler; //!< Queues an event for a OCSyncRecordID. Under the hood, adds this to the events table while keeping it cached in memory (to preserve ephermal data).

--- a/ownCloudSDK/Wait Condition/OCWaitCondition.h
+++ b/ownCloudSDK/Wait Condition/OCWaitCondition.h
@@ -25,7 +25,8 @@ typedef NS_ENUM(NSInteger, OCWaitConditionState)
 {
 	OCWaitConditionStateWait,	//!< The condition has not yet been made. Continue to wait.
 	OCWaitConditionStateProceed,	//!< The condition has been met permanently. Proceed.
-	OCWaitConditionStateFail	//!< The condition has failed with an error. Resolve.
+	OCWaitConditionStateFail,	//!< The condition has failed with an error. Resolve.
+	OCWaitConditionStateDeschedule	//!< The condition is not met permanently. Deschedule action.
 };
 
 typedef NSString* OCWaitConditionOption;

--- a/ownCloudSDK/Wait Condition/OCWaitConditionAvailableOffline.h
+++ b/ownCloudSDK/Wait Condition/OCWaitConditionAvailableOffline.h
@@ -1,0 +1,27 @@
+//
+//  OCWaitConditionAvailableOffline.h
+//  ownCloudSDK
+//
+//  Created by Felix Schwarz on 22.07.24.
+//  Copyright © 2024 ownCloud GmbH. All rights reserved.
+//
+
+/*
+ * Copyright (C) 2024, ownCloud GmbH.
+ *
+ * This code is covered by the GNU Public License Version 3.
+ *
+ * For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+ * You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+ *
+ */
+
+#import <ownCloudSDK/ownCloudSDK.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OCWaitConditionAvailableOffline : OCWaitCondition
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ownCloudSDK/Wait Condition/OCWaitConditionAvailableOffline.m
+++ b/ownCloudSDK/Wait Condition/OCWaitConditionAvailableOffline.m
@@ -1,0 +1,82 @@
+//
+//  OCWaitConditionAvailableOffline.m
+//  ownCloudSDK
+//
+//  Created by Felix Schwarz on 22.07.24.
+//  Copyright © 2024 ownCloud GmbH. All rights reserved.
+//
+
+/*
+ * Copyright (C) 2024, ownCloud GmbH.
+ *
+ * This code is covered by the GNU Public License Version 3.
+ *
+ * For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+ * You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+ *
+ */
+
+#import "OCWaitConditionAvailableOffline.h"
+#import "OCSyncAction.h"
+
+@implementation OCWaitConditionAvailableOffline
+
+- (void)evaluateWithOptions:(OCWaitConditionOptions)options completionHandler:(OCWaitConditionEvaluationResultHandler)completionHandler
+{
+	OCCore *core = options[OCWaitConditionOptionCore];
+	OCSyncRecord *syncRecord = options[OCWaitConditionOptionSyncRecord];
+	OCItem *item = syncRecord.action.localItem;
+
+	if ((core != nil) && (item != nil))
+	{
+		OCCoreAvailableOfflineCoverage availableOfflineCoverage;
+		availableOfflineCoverage = [core availableOfflinePolicyCoverageOfItem:item]; // Attention: this method only performs a QUICK check based on location, not actual policy conditions, so when Available Offline is implemented for Saved Searches, this must be changed to a precise implementation
+
+		switch (availableOfflineCoverage)
+		{
+			case OCCoreAvailableOfflineCoverageNone:
+				// File not / no longer included in available offline scope
+				OCLogDebug(@"AOCheck: Cancelled %@", item.location.string);
+				completionHandler(OCWaitConditionStateDeschedule, NO, OCError(OCErrorCancelled));
+				return;
+			break;
+
+			case OCCoreAvailableOfflineCoverageIndirect:
+			case OCCoreAvailableOfflineCoverageDirect:
+				// File is included in available offline scope
+				OCLogDebug(@"AOCheck: Approved %@", item.location.string);
+				completionHandler(OCWaitConditionStateProceed, NO, nil);
+				return;
+			break;
+		}
+	}
+	else
+	{
+		// Core and item are the minimum needed to make a decision
+		OCLogDebug(@"AOCheck: Failed 1 %@", item.location.string);
+		completionHandler(OCWaitConditionStateFail, NO, OCError(OCErrorInsufficientParameters));
+		return;
+	}
+
+	OCLogDebug(@"AOCheck: Failed 2 %@", item.location.string);
+	completionHandler(OCWaitConditionStateFail, NO, OCError(OCErrorInternal)); // Catch-all that should never be hit
+}
+
+
+#pragma mark - Secure Coding
++ (BOOL)supportsSecureCoding
+{
+	return (YES);
+}
+
+- (void)encodeWithCoder:(nonnull NSCoder *)coder
+{
+	[super encodeWithCoder:coder];
+}
+
+- (nullable instancetype)initWithCoder:(nonnull NSCoder *)decoder
+{
+	return ([super initWithCoder:decoder]);
+}
+
+@end


### PR DESCRIPTION
## Description
This PR adds
- [x] documentation on the Item Policy architecture
- [x] a new Wait Condition to cancel scheduled downloads before execution if Available Offline is no longer wanted for an item
- [x] adds deeper Sync Engine integration, allowing Item Policies to stretch out work in a more efficient manner, especially when matching a great number of items.

## Related Issue
https://github.com/owncloud/ios-app/pull/1351

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
