### PR TITLE
[fix/fp-memory] Reduce FP memory consumption

### DIFF
--- a/ownCloudSDK/Bookmark/OCBookmark+DataItem.m
+++ b/ownCloudSDK/Bookmark/OCBookmark+DataItem.m
@@ -20,6 +20,7 @@
 #import "OCDataTypes.h"
 #import "OCResource.h"
 #import "OCMacros.h"
+#import "OCCoreManager.h"
 
 @implementation OCBookmark (DataItem)
 
@@ -35,10 +36,17 @@
 
 - (OCDataItemVersion)dataItemVersion
 {
-	OCResource *avatarResource = OCTypedCast(self.avatar, OCResource);
-	NSString *avatarVersion = ((avatarResource != nil) ? avatarResource.version : @"");
+	if (OCCoreManager.sharedCoreManager.memoryConfiguration != OCCoreMemoryConfigurationMinimum)
+	{
+		OCResource *avatarResource = OCTypedCast(self.avatar, OCResource);
+		NSString *avatarVersion = ((avatarResource != nil) ? avatarResource.version : @"");
 
-	return ([NSString stringWithFormat:@"%@%@%@%@%@%@%@", self.name, self.url, self.originURL, self.userName, self.userDisplayName, self.authenticationDataID, avatarVersion]);
+		return ([NSString stringWithFormat:@"%@%@%@%@%@%@%@", self.name, self.url, self.originURL, self.userName, self.userDisplayName, self.authenticationDataID, avatarVersion]);
+	}
+	else
+	{
+		return ([NSString stringWithFormat:@"%@%@%@%@%@%@", self.name, self.url, self.originURL, self.userName, self.userDisplayName, self.authenticationDataID]);
+	}
 }
 
 @end

--- a/ownCloudSDK/Resource Management/OCCoreManager.m
+++ b/ownCloudSDK/Resource Management/OCCoreManager.m
@@ -425,7 +425,7 @@
 		switch (memoryConfiguration)
 		{
 			case OCCoreMemoryConfigurationMinimum:
-				[OCSQLiteDB setMemoryLimit:(1 * 1024 * 1024)]; // Set 1 MB memory limit for SQLite;
+				[OCSQLiteDB setMemoryLimit:(1 * 1024 * 512)]; // Set 0.5 MB memory limit for SQLite;
 			break;
 
 			default: break;

--- a/ownCloudSDK/Toolkit/OCIPNotificationCenter.m
+++ b/ownCloudSDK/Toolkit/OCIPNotificationCenter.m
@@ -76,7 +76,9 @@ static void OCIPNotificationCenterCallback(CFNotificationCenterRef center, void 
 {
 	OCIPNotificationCenter *notificationCenter = (__bridge OCIPNotificationCenter *)observer;
 
-	[notificationCenter deliverNotificationForName:(__bridge OCIPCNotificationName)name];
+	@autoreleasepool {
+		[notificationCenter deliverNotificationForName:(__bridge OCIPCNotificationName)name];
+	}
 }
 
 - (void)enable:(BOOL)enable observationForName:(NSString *)name

--- a/ownCloudSDK/Vaults/Database/OCDatabase.m
+++ b/ownCloudSDK/Vaults/Database/OCDatabase.m
@@ -336,7 +336,7 @@
 				completionHandler(self, error);
 			}
 		}]];
-	} segmentSize:((_memoryConfiguration == OCCoreMemoryConfigurationMinimum) ? 20 : 200)];
+	} segmentSize:((_memoryConfiguration == OCCoreMemoryConfigurationMinimum) ? 10 : 200)];
 }
 
 - (void)updateCacheItems:(NSArray <OCItem *> *)items syncAnchor:(OCSyncAnchor)syncAnchor completionHandler:(OCDatabaseCompletionHandler)completionHandler
@@ -452,7 +452,7 @@
 				completionHandler(self, error);
 			}
 		}]];
-	} segmentSize:((_memoryConfiguration == OCCoreMemoryConfigurationMinimum) ? 20 : 200)];
+	} segmentSize:((_memoryConfiguration == OCCoreMemoryConfigurationMinimum) ? 10 : 200)];
 }
 
 - (void)removeCacheItems:(NSArray <OCItem *> *)items syncAnchor:(OCSyncAnchor)syncAnchor completionHandler:(OCDatabaseCompletionHandler)completionHandler

--- a/ownCloudSDK/Vaults/Database/SQLite/OCSQLiteDB.m
+++ b/ownCloudSDK/Vaults/Database/SQLite/OCSQLiteDB.m
@@ -1245,6 +1245,7 @@ static void collationProvider(void *dbObj, sqlite3 *db, int eTextRep, const char
 
 + (int64_t)setMemoryLimit:(int64_t)memoryLimit
 {
+	sqlite3_config(SQLITE_CONFIG_MEMSTATUS, true);
 	int64_t previousMemoryLimit = sqlite3_soft_heap_limit64(memoryLimit);
 
 	OCLogDebug(@"Changed memory limit from %lld to %lld bytes", previousMemoryLimit, memoryLimit);


### PR DESCRIPTION
## Description
- OCBookmark+DataItem: avoid de-serialization (and memory consumption) of avatar resource in minimum memory configuration
- OCBookmarkManager: quickly release memory from serialized and deserialized bookmarks via autoreleasepools to reduce peak memory consumption loading and saving bookmarks
- OCCoreManager: reduce SQLite memory limit from 1 MB to 512 KB
- OCIPNotificationCenter: handle notifications inside an autorelease pool to reduce peak memory usage
- OCDatabase: reduce segment size stepping through the database to reduce peak memory usage
- OCSQLiteDB: ensure sqlite3_soft_heap_limit64() becomes effective by enabling SQLite memory tracking

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
