### PR TITLE
[fix/transifex-duplicate-keys] Remove duplicate locale keys before push and after pull from Transifex

### DIFF
--- a/.github/workflows/pull-transifex.yml
+++ b/.github/workflows/pull-transifex.yml
@@ -25,7 +25,7 @@ jobs:
         shell: bash
         run: |
           beautifyJSON() {
-            jq --sort-keys . $1 >$1.tmp
+            jq --sort-keys 'walk(if type == "object" then del(."th_TH", ."pt_PT", ."pt_BR", ."nn_NO", ."nb_NO", ."en_GB") else . end)' $1 >$1.tmp
             mv $1.tmp $1
           }
           beautifyJSON "ownCloudSDK/Resources/Localizable.xcstrings"

--- a/.github/workflows/push-transifex.yml
+++ b/.github/workflows/push-transifex.yml
@@ -12,6 +12,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: l10n-format
+        shell: bash
+        run: |
+          beautifyJSON() {
+            jq --sort-keys 'walk(if type == "object" then del(."th_TH", ."pt_PT", ."pt_BR", ."nn_NO", ."nb_NO", ."en_GB") else . end)' $1 >$1.tmp
+            mv $1.tmp $1
+          }
+          beautifyJSON "ownCloudSDK/Resources/Localizable.xcstrings"
+          beautifyJSON "ownCloudUI/Resources/Localizable.xcstrings"
+
       - name: l10n-push-source
         uses: transifex/cli-action@v2
         with:

--- a/ownCloudSDK/Resources/Localizable.xcstrings
+++ b/ownCloudSDK/Resources/Localizable.xcstrings
@@ -27,12 +27,6 @@
             "value": "\"%@\" has been modified locally"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "\"%@\" has been modified locally"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -57,34 +51,10 @@
             "value": "\"%@\" has been modified locally"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "\"%@\" has been modified locally"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "\"%@\" has been modified locally"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "\"%@\" foi modificado localmente "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "\"%@\" foi modificado localmente "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "\"%@\" has been modified locally"
           }
         },
         "ru": {
@@ -100,12 +70,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "\"%@\" ได้รับการแก้ไขแล้วในเครื่อง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "\"%@\" ได้รับการแก้ไขแล้วในเครื่อง"
@@ -152,12 +116,6 @@
             "value": "\"%@\" metadata for %@ couldn't be updated"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "\"%@\" metadata for %@ couldn't be updated"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -188,19 +146,7 @@
             "value": "\"%@\" metadata for %@ couldn't be updated"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "\"%@\" metadata for %@ couldn't be updated"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "\"%@\" metadata for %@ couldn't be updated"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "\"%@\" metadata for %@ couldn't be updated"
@@ -210,18 +156,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "\"%@\" metadados para %@ não puderam ser atualizados"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "\"%@\" metadados para %@ não puderam ser atualizados"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "\"%@\" metadata for %@ couldn't be updated"
           }
         },
         "ru": {
@@ -237,12 +171,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "\"%@\" metadata สำหรับ %@ ไม่สามารถอัปเดตได้"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "\"%@\" metadata สำหรับ %@ ไม่สามารถอัปเดตได้"
@@ -288,12 +216,6 @@
             "value": "\"%@\" was modified locally before the download completed."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "\"%@\" was modified locally before the download completed."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -318,34 +240,10 @@
             "value": "\"%@\" was modified locally before the download completed."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "\"%@\" was modified locally before the download completed."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "\"%@\" was modified locally before the download completed."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "\"%@\" foi modificado localmente antes da conclusão de baixar o arquivo. "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "\"%@\" foi modificado localmente antes da conclusão de baixar o arquivo. "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "\"%@\" was modified locally before the download completed."
           }
         },
         "ru": {
@@ -361,12 +259,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "\"%@\" ได้ถูกแก้ไขในเครื่องก่อนที่การดาวน์โหลดจะเสร็จสมบูรณ์"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "\"%@\" ได้ถูกแก้ไขในเครื่องก่อนที่การดาวน์โหลดจะเสร็จสมบูรณ์"
@@ -413,12 +305,6 @@
             "value": "%@ (error %ld)"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ (error %ld)"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -449,19 +335,7 @@
             "value": "%@ (error %ld)"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ (error %ld)"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ (error %ld)"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "%@ (error %ld)"
@@ -471,18 +345,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ (erro %ld)"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ (erro %ld)"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ (error %ld)"
           }
         },
         "ru": {
@@ -498,12 +360,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ (ข้อผิดพลาด %ld)"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "%@ (ข้อผิดพลาด %ld)"
@@ -551,12 +407,6 @@
             "value": "%@ (error %ld, %@)"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ (error %ld, %@)"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -587,19 +437,7 @@
             "value": "%@ (error %ld, %@)"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ (error %ld, %@)"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ (error %ld, %@)"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "%@ (error %ld, %@)"
@@ -609,18 +447,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ (erro %ld, %@)"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ (erro %ld, %@)"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ (error %ld, %@)"
           }
         },
         "ru": {
@@ -636,12 +462,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@(ข้อผิดพลาด %ld, %@)"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "%@(ข้อผิดพลาด %ld, %@)"
@@ -687,12 +507,6 @@
             "value": "%@ already exists"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ already exists"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -723,19 +537,7 @@
             "value": "%@ already exists"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ already exists"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ already exists"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "%@ already exists"
@@ -745,18 +547,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ já existe"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ já existe"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ already exists"
           }
         },
         "ru": {
@@ -772,12 +562,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@มีอยู่แล้ว "
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "%@มีอยู่แล้ว "
@@ -823,12 +607,6 @@
             "value": "%@ can't be copied to %@."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ can't be copied to %@."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -859,19 +637,7 @@
             "value": "%@ can't be copied to %@."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ can't be copied to %@."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ can't be copied to %@."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "%@ can't be copied to %@."
@@ -881,18 +647,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ não pode ser copiado para %@."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ não pode ser copiado para %@."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ can't be copied to %@."
           }
         },
         "ru": {
@@ -908,12 +662,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่สามารถคัดลอก %@ ไปที่ %@"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไม่สามารถคัดลอก %@ ไปที่ %@"
@@ -959,12 +707,6 @@
             "value": "%@ can't be moved to %@."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ can't be moved to %@."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -995,19 +737,7 @@
             "value": "%@ can't be moved to %@."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ can't be moved to %@."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ can't be moved to %@."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "%@ can't be moved to %@."
@@ -1017,18 +747,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ não pode ser movido para %@."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ não pode ser movido para %@."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ can't be moved to %@."
           }
         },
         "ru": {
@@ -1044,12 +762,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่สามารถย้าย %@ ไปที่ %@"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไม่สามารถย้าย %@ ไปที่ %@"
@@ -1095,12 +807,6 @@
             "value": "%@ couldn't be renamed to %@."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ couldn't be renamed to %@."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -1125,34 +831,10 @@
             "value": "%@ couldn't be renamed to %@."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ couldn't be renamed to %@."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ couldn't be renamed to %@."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "%@ não pôde ser renomeado para %@."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ não pôde ser renomeado para %@."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ couldn't be renamed to %@."
           }
         },
         "ru": {
@@ -1168,12 +850,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ couldn't be renamed to %@."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "%@ couldn't be renamed to %@."
@@ -1220,12 +896,6 @@
             "value": "%@ changed on the server. Really delete it?"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ changed on the server. Really delete it?"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -1256,19 +926,7 @@
             "value": "%@ changed on the server. Really delete it?"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ changed on the server. Really delete it?"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ changed on the server. Really delete it?"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "%@ changed on the server. Really delete it?"
@@ -1278,18 +936,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ mudou no servidor. Realmente deletar?"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ mudou no servidor. Realmente deletar?"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ changed on the server. Really delete it?"
           }
         },
         "ru": {
@@ -1305,12 +951,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ได้เปลี่ยนเซิร์ฟเวอร์แล้ว ต้องการลบ?"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "%@ได้เปลี่ยนเซิร์ฟเวอร์แล้ว ต้องการลบ?"
@@ -1356,12 +996,6 @@
             "value": "%@ couldn't be deleted"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ couldn't be deleted"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -1392,19 +1026,7 @@
             "value": "%@ couldn't be deleted"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ couldn't be deleted"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ couldn't be deleted"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "%@ couldn't be deleted"
@@ -1414,18 +1036,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ não pôde ser excluído"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ não pôde ser excluído"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ couldn't be deleted"
           }
         },
         "ru": {
@@ -1441,12 +1051,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ไม่สามารถลบได้ "
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "%@ไม่สามารถลบได้ "
@@ -1486,12 +1090,6 @@
             "value": "%1$@ couldn't be renamed to %2$@."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ couldn't be renamed to %2$@."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -1516,30 +1114,6 @@
             "value": "%1$@ couldn't be renamed to %2$@."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ couldn't be renamed to %2$@."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ couldn't be renamed to %2$@."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ couldn't be renamed to %2$@."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ couldn't be renamed to %2$@."
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -1547,12 +1121,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ couldn't be renamed to %2$@."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "%1$@ couldn't be renamed to %2$@."
@@ -1598,12 +1166,6 @@
             "value": "%@ has changed on the server since you requested its deletion."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ has changed on the server since you requested its deletion."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -1634,19 +1196,7 @@
             "value": "%@ has changed on the server since you requested its deletion."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ has changed on the server since you requested its deletion."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ has changed on the server since you requested its deletion."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "%@ has changed on the server since you requested its deletion."
@@ -1656,18 +1206,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ mudou no servidor desde que você solicitou sua exclusão."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ mudou no servidor desde que você solicitou sua exclusão."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ has changed on the server since you requested its deletion."
           }
         },
         "ru": {
@@ -1683,12 +1221,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ ได้เปลี่ยนเซิร์ฟเวอร์แล้วตั้งแต่คุณขอให้ลบ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "%@ ได้เปลี่ยนเซิร์ฟเวอร์แล้วตั้งแต่คุณขอให้ลบ"
@@ -1734,12 +1266,6 @@
             "value": "%@ not found"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ not found"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -1770,19 +1296,7 @@
             "value": "%@ not found"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ not found"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ not found"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "%@ not found"
@@ -1792,18 +1306,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ não encontrado"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ não encontrado"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ not found"
           }
         },
         "ru": {
@@ -1819,12 +1321,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่พบ %@"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไม่พบ %@"
@@ -1870,12 +1366,6 @@
             "value": "%@ wasn't found at %@."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ wasn't found at %@."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -1906,19 +1396,7 @@
             "value": "%@ wasn't found at %@."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ wasn't found at %@."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ wasn't found at %@."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "%@ wasn't found at %@."
@@ -1928,18 +1406,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ não foi encontrado em %@."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ não foi encontrado em %@."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ wasn't found at %@."
           }
         },
         "ru": {
@@ -1955,12 +1421,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่พบ %@ ที่ %@"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไม่พบ %@ ที่ %@"
@@ -2006,12 +1466,6 @@
             "value": "%lu files in %lu folders"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lu files in %lu folders"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -2036,34 +1490,10 @@
             "value": "%lu files in %lu folders"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lu files in %lu folders"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lu files in %lu folders"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "%lu arquivos em pastas %lu"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lu arquivos em pastas %lu"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lu files in %lu folders"
           }
         },
         "ru": {
@@ -2079,12 +1509,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lu files in %lu folders"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "%lu files in %lu folders"
@@ -2130,12 +1554,6 @@
             "value": "A modified, unsynchronised version of \"%@\" is present on your device. Downloading the file from the server will overwrite it and modifications be lost."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A modified, unsynchronised version of \"%@\" is present on your device. Downloading the file from the server will overwrite it and modifications be lost."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -2160,34 +1578,10 @@
             "value": "A modified, unsynchronized version of \"%@\" is present on your device. Downloading the file from the server will overwrite it and modifications be lost."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A modified, unsynchronized version of \"%@\" is present on your device. Downloading the file from the server will overwrite it and modifications be lost."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A modified, unsynchronized version of \"%@\" is present on your device. Downloading the file from the server will overwrite it and modifications be lost."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Uma versão modificada e não sincronizada de  \"%@\" está presente em seu dispositivo. Baixar o arquivo do servidor irá sobrescrevê-lo e as modificações serão perdidas. "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uma versão modificada e não sincronizada de  \"%@\" está presente em seu dispositivo. Baixar o arquivo do servidor irá sobrescrevê-lo e as modificações serão perdidas. "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A modified, unsynchronized version of \"%@\" is present on your device. Downloading the file from the server will overwrite it and modifications be lost."
           }
         },
         "ru": {
@@ -2203,12 +1597,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การแก้ไขและไม่ได้ถูกประสานข้อมูลของเวอร์ชัน \"%@\" จะแสดงอยู่บนอุปกรณ์ของคุณ การดาวน์โหลดไฟล์จากเซิร์ฟเวอร์จะเขียนทับไฟล์ดังกล่าวและการแก้ไขจะสูญหายไป"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "การแก้ไขและไม่ได้ถูกประสานข้อมูลของเวอร์ชัน \"%@\" จะแสดงอยู่บนอุปกรณ์ของคุณ การดาวน์โหลดไฟล์จากเซิร์ฟเวอร์จะเขียนทับไฟล์ดังกล่าวและการแก้ไขจะสูญหายไป"
@@ -2256,12 +1644,6 @@
             "value": "A newer version already exists."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A newer version already exists."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -2292,19 +1674,7 @@
             "value": "A newer version already exists."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A newer version already exists."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A newer version already exists."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "A newer version already exists."
@@ -2314,18 +1684,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Uma versão mais nova já existe."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uma versão mais nova já existe."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A newer version already exists."
           }
         },
         "ru": {
@@ -2341,12 +1699,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "มีเวอร์ชันใหม่ออกมาแล้ว"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "มีเวอร์ชันใหม่ออกมาแล้ว"
@@ -2394,12 +1746,6 @@
             "value": "A running operation prevents execution."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A running operation prevents execution."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -2430,19 +1776,7 @@
             "value": "A running operation prevents execution."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A running operation prevents execution."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A running operation prevents execution."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "A running operation prevents execution."
@@ -2452,18 +1786,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Uma outra operação em execução impede a execução."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uma outra operação em execução impede a execução."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A running operation prevents execution."
           }
         },
         "ru": {
@@ -2479,12 +1801,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การดำเนินการที่ทำงานอยู่จะป้องกันการดำเนินการอื่น ๆ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "การดำเนินการที่ทำงานอยู่จะป้องกันการดำเนินการอื่น ๆ"
@@ -2524,12 +1840,6 @@
             "value": "Accepting share…"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Accepting share…"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -2554,30 +1864,6 @@
             "value": "Accepting share…"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Accepting share…"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Accepting share…"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Accepting share…"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Accepting share…"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -2585,12 +1871,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Accepting share…"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Accepting share…"
@@ -2636,12 +1916,6 @@
             "value": "Action"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Action"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -2666,34 +1940,10 @@
             "value": "Action"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Action"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Action"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Ação"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ação"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Action"
           }
         },
         "ru": {
@@ -2709,12 +1959,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การกระทำ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "การกระทำ"
@@ -2760,12 +2004,6 @@
             "value": "Action ID"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Action ID"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -2790,34 +2028,10 @@
             "value": "Action ID"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Action ID"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Action ID"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "ID da ação "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ID da ação "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Action ID"
           }
         },
         "ru": {
@@ -2833,12 +2047,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "รหัสการดำเนินการ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "รหัสการดำเนินการ"
@@ -2885,12 +2093,6 @@
             "value": "Allow cellular access"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Allow cellular access"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -2915,34 +2117,10 @@
             "value": "Allow cellular access"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Allow cellular access"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Allow cellular access"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Permitir acesso do celular "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permitir acesso do celular "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Allow cellular access"
           }
         },
         "ru": {
@@ -2958,12 +2136,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "อนุญาตการเข้าถึงเครือข่ายมือถือ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "อนุญาตการเข้าถึงเครือข่ายมือถือ"
@@ -3003,12 +2175,6 @@
             "value": "An error occured trying to validate the certificate for %@."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An error occured trying to validate the certificate for %@."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -3033,30 +2199,6 @@
             "value": "An error occured trying to validate the certificate for %@."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An error occured trying to validate the certificate for %@."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An error occured trying to validate the certificate for %@."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An error occured trying to validate the certificate for %@."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An error occured trying to validate the certificate for %@."
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -3064,12 +2206,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An error occured trying to validate the certificate for %@."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "An error occured trying to validate the certificate for %@."
@@ -3109,12 +2245,6 @@
             "value": "An exception occured attempting to perform an action (\"%@\"). The action has been removed from the sync queue and may not have completed. If logging is enabled, the exception has been logged."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An exception occured attempting to perform an action (\"%@\"). The action has been removed from the sync queue and may not have completed. If logging is enabled, the exception has been logged."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -3139,30 +2269,6 @@
             "value": "An exception occured attempting to perform an action (\"%@\"). The action has been removed from the sync queue and may not have completed. If logging is enabled, the exception has been logged."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An exception occured attempting to perform an action (\"%@\"). The action has been removed from the sync queue and may not have completed. If logging is enabled, the exception has been logged."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An exception occured attempting to perform an action (\"%@\"). The action has been removed from the sync queue and may not have completed. If logging is enabled, the exception has been logged."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An exception occured attempting to perform an action (\"%@\"). The action has been removed from the sync queue and may not have completed. If logging is enabled, the exception has been logged."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An exception occured attempting to perform an action (\"%@\"). The action has been removed from the sync queue and may not have completed. If logging is enabled, the exception has been logged."
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -3170,12 +2276,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An exception occured attempting to perform an action (\"%@\"). The action has been removed from the sync queue and may not have completed. If logging is enabled, the exception has been logged."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "An exception occured attempting to perform an action (\"%@\"). The action has been removed from the sync queue and may not have completed. If logging is enabled, the exception has been logged."
@@ -3223,12 +2323,6 @@
             "value": "An exception occurred."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An exception occurred."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -3259,19 +2353,7 @@
             "value": "An exception occured."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An exception occured."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An exception occured."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "An exception occured."
@@ -3281,18 +2363,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Uma exceção ocorreu."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uma exceção ocorreu."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An exception occured."
           }
         },
         "ru": {
@@ -3308,12 +2378,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "มีข้อยกเว้นเกิดขึ้น"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "มีข้อยกเว้นเกิดขึ้น"
@@ -3361,12 +2425,6 @@
             "value": "An operation failed due to outdated cache information."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An operation failed due to outdated cache information."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -3397,19 +2455,7 @@
             "value": "An operation failed due to outdated cache information."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An operation failed due to outdated cache information."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An operation failed due to outdated cache information."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "An operation failed due to outdated cache information."
@@ -3419,18 +2465,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Uma operação falhou devido a informações de cache desatualizadas."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uma operação falhou devido a informações de cache desatualizadas."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An operation failed due to outdated cache information."
           }
         },
         "ru": {
@@ -3446,12 +2480,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การดำเนินการล้มเหลวเนื่องจากข้อมูลแคชที่ล้าสมัย"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "การดำเนินการล้มเหลวเนื่องจากข้อมูลแคชที่ล้าสมัย"
@@ -3498,12 +2526,6 @@
             "value": "Another item named %@ already exists in %@."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Another item named %@ already exists in %@."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -3528,34 +2550,10 @@
             "value": "Another item named %@ already exists in %@."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Another item named %@ already exists in %@."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Another item named %@ already exists in %@."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Outro item chamado %@ já existe em %@."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Outro item chamado %@ já existe em %@."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Another item named %@ already exists in %@."
           }
         },
         "ru": {
@@ -3571,12 +2569,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "อีกรายการชื่อ %@ มีอยู่แล้วใน %@"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "อีกรายการชื่อ %@ มีอยู่แล้วใน %@"
@@ -3624,12 +2616,6 @@
             "value": "Another item policy of the same kind already includes the item, making the addition of this item policy redundant."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Another item policy of the same kind already includes the item, making the addition of this item policy redundant."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -3654,34 +2640,10 @@
             "value": "Another item policy of the same kind already includes the item, making the addition of this item policy redundant."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Another item policy of the same kind already includes the item, making the addition of this item policy redundant."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Another item policy of the same kind already includes the item, making the addition of this item policy redundant."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Outra política de itens do mesmo tipo já inclui o item, tornando redundante a adição desta política de itens. "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Outra política de itens do mesmo tipo já inclui o item, tornando redundante a adição desta política de itens. "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Another item policy of the same kind already includes the item, making the addition of this item policy redundant."
           }
         },
         "ru": {
@@ -3697,12 +2659,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "นโยบายสินค้าซ้ำกับสินค้าที่มีอยู่แล้ว ทำให้ไม่สามารถเพิ่มนโยบาย"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "นโยบายสินค้าซ้ำกับสินค้าที่มีอยู่แล้ว ทำให้ไม่สามารถเพิ่มนโยบาย"
@@ -3744,12 +2700,6 @@
             "value": "At least {{min}} special characters: {{specialCharacters}}"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "At least {{min}} special characters: {{specialCharacters}}"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -3774,30 +2724,6 @@
             "value": "At least {{min}} special characters: {{specialCharacters}}"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "At least {{min}} special characters: {{specialCharacters}}"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "At least {{min}} special characters: {{specialCharacters}}"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "At least {{min}} special characters: {{specialCharacters}}"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "At least {{min}} special characters: {{specialCharacters}}"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -3805,12 +2731,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "At least {{min}} special characters: {{specialCharacters}}"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "At least {{min}} special characters: {{specialCharacters}}"
@@ -3852,12 +2772,6 @@
             "value": "At least {{min}} {{characterType}}"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "At least {{min}} {{characterType}}"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -3882,30 +2796,6 @@
             "value": "At least {{min}} {{characterType}}"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "At least {{min}} {{characterType}}"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "At least {{min}} {{characterType}}"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "At least {{min}} {{characterType}}"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "At least {{min}} {{characterType}}"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -3913,12 +2803,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "At least {{min}} {{characterType}}"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "At least {{min}} {{characterType}}"
@@ -3960,12 +2844,6 @@
             "value": "At most {{byteLength}} bytes."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "At most {{byteLength}} bytes."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -3990,30 +2868,6 @@
             "value": "At most {{byteLength}} bytes."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "At most {{byteLength}} bytes."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "At most {{byteLength}} bytes."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "At most {{byteLength}} bytes."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "At most {{byteLength}} bytes."
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -4021,12 +2875,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "At most {{byteLength}} bytes."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "At most {{byteLength}} bytes."
@@ -4068,12 +2916,6 @@
             "value": "At most {{max}} {{characterType}}"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "At most {{max}} {{characterType}}"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -4098,30 +2940,6 @@
             "value": "At most {{max}} {{characterType}}"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "At most {{max}} {{characterType}}"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "At most {{max}} {{characterType}}"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "At most {{max}} {{characterType}}"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "At most {{max}} {{characterType}}"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -4129,12 +2947,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "At most {{max}} {{characterType}}"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "At most {{max}} {{characterType}}"
@@ -4180,12 +2992,6 @@
             "value": "Auth Data"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auth Data"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -4210,34 +3016,10 @@
             "value": "Auth Data"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auth Data"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auth Data"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Dados de Autenticação "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dados de Autenticação "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auth Data"
           }
         },
         "ru": {
@@ -4253,12 +3035,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ข้อมูลรับรองความถูกต้อง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ข้อมูลรับรองความถูกต้อง"
@@ -4304,12 +3080,6 @@
             "value": "Auth Method"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auth Method"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -4334,34 +3104,10 @@
             "value": "Auth Method"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auth Method"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auth Method"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Método de Autenticação "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Método de Autenticação "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auth Method"
           }
         },
         "ru": {
@@ -4377,12 +3123,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "วิธีการรับรองความถูกต้อง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "วิธีการรับรองความถูกต้อง"
@@ -4428,12 +3168,6 @@
             "value": "Auth Validation Date"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auth Validation Date"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -4458,34 +3192,10 @@
             "value": "Auth Validation Date"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auth Validation Date"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auth Validation Date"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Data de Validação de Autenticação "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Data de Validação de Autenticação "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auth Validation Date"
           }
         },
         "ru": {
@@ -4501,12 +3211,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "วันที่ตรวจสอบสิทธิ์"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "วันที่ตรวจสอบสิทธิ์"
@@ -4552,12 +3256,6 @@
             "value": "Authenticating…"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authenticating…"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -4588,19 +3286,7 @@
             "value": "Authenticating…"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authenticating…"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authenticating…"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Authenticating…"
@@ -4613,18 +3299,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A autenticar..."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Autenticando..."
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "A autenticar..."
@@ -4643,12 +3317,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กำลังตรวจสอบสิทธิ์..."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "กำลังตรวจสอบสิทธิ์..."
@@ -4696,12 +3364,6 @@
             "value": "Authentication method not allowed. Re-authentication needed."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authentication method not allowed. Re-authentication needed."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -4726,34 +3388,10 @@
             "value": "Authentication method not allowed. Re-authentication needed."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authentication method not allowed. Re-authentication needed."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authentication method not allowed. Re-authentication needed."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Método de autenticação não permitido. Re-autenticação necessária. "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Método de autenticação não permitido. Re-autenticação necessária. "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authentication method not allowed. Re-authentication needed."
           }
         },
         "ru": {
@@ -4769,12 +3407,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่อนุญาตให้ใช้วิธีการรับรองความถูกต้อง จำเป็นต้องมีการตรวจสอบสิทธิ์อีกครั้ง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไม่อนุญาตให้ใช้วิธีการรับรองความถูกต้อง จำเป็นต้องมีการตรวจสอบสิทธิ์อีกครั้ง"
@@ -4822,12 +3454,6 @@
             "value": "Authentication method unknown."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authentication method unknown."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -4852,34 +3478,10 @@
             "value": "Authentication method unknown."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authentication method unknown."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authentication method unknown."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Método de autenticação desconhecido. "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Método de autenticação desconhecido. "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authentication method unknown."
           }
         },
         "ru": {
@@ -4895,12 +3497,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่รู้จักวิธีการรับรองความถูกต้อง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไม่รู้จักวิธีการรับรองความถูกต้อง"
@@ -4948,12 +3544,6 @@
             "value": "Authorisation failed because data was missing from the secret data for the authentication method."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorisation failed because data was missing from the secret data for the authentication method."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -4984,19 +3574,7 @@
             "value": "Authorization failed because data was missing from the secret data for the authentication method."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorization failed because data was missing from the secret data for the authentication method."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorization failed because data was missing from the secret data for the authentication method."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Authorization failed because data was missing from the secret data for the authentication method."
@@ -5006,18 +3584,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "A autorização falhou porque faltavam dados dos dados secretos para o método de autenticação."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A autorização falhou porque faltavam dados dos dados secretos para o método de autenticação."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorization failed because data was missing from the secret data for the authentication method."
           }
         },
         "ru": {
@@ -5033,12 +3599,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การอนุญาตล้มเหลวเนื่องจากข้อมูลลับสำหรับการตรวจสอบสิทธิ์หายไป"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "การอนุญาตล้มเหลวเนื่องจากข้อมูลลับสำหรับการตรวจสอบสิทธิ์หายไป"
@@ -5086,12 +3646,6 @@
             "value": "Authorisation failed because no authorisation data was set for the authentication method."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorisation failed because no authorisation data was set for the authentication method."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -5122,19 +3676,7 @@
             "value": "Authorization failed because no authorization data was set for the authentication method."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorization failed because no authorization data was set for the authentication method."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorization failed because no authorization data was set for the authentication method."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Authorization failed because no authorization data was set for the authentication method."
@@ -5144,18 +3686,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "A autorização falhou porque nenhum dado de autorização foi definido para o método de autenticação."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A autorização falhou porque nenhum dado de autorização foi definido para o método de autenticação."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorization failed because no authorization data was set for the authentication method."
           }
         },
         "ru": {
@@ -5171,12 +3701,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorization failed because no authorization data was set for the authentication method."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Authorization failed because no authorization data was set for the authentication method."
@@ -5224,12 +3748,6 @@
             "value": "Authorisation failed because the server returned a redirect. Authorisation may be successful when retried with the redirect URL."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorisation failed because the server returned a redirect. Authorisation may be successful when retried with the redirect URL."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -5260,19 +3778,7 @@
             "value": "Authorization failed because the server returned a redirect. Authorization may be successful when retried with the redirect URL."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorization failed because the server returned a redirect. Authorization may be successful when retried with the redirect URL."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorization failed because the server returned a redirect. Authorization may be successful when retried with the redirect URL."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Authorization failed because the server returned a redirect. Authorization may be successful when retried with the redirect URL."
@@ -5282,18 +3788,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "A autorização falhou porque o servidor retornou um redirecionamento. A autorização pode ser bem-sucedida quando você tentar novamente com o URL de redirecionamento."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A autorização falhou porque o servidor retornou um redirecionamento. A autorização pode ser bem-sucedida quando você tentar novamente com o URL de redirecionamento."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorization failed because the server returned a redirect. Authorization may be successful when retried with the redirect URL."
           }
         },
         "ru": {
@@ -5309,12 +3803,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การอนุญาตล้มเหลวเนื่องจากเซิร์ฟเวอร์ส่งคืนการเปลี่ยนเส้นทาง ลองใช้ URL การเปลี่ยนเส้นทางใหม่"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "การอนุญาตล้มเหลวเนื่องจากเซิร์ฟเวอร์ส่งคืนการเปลี่ยนเส้นทาง ลองใช้ URL การเปลี่ยนเส้นทางใหม่"
@@ -5362,12 +3850,6 @@
             "value": "Authorisation failed."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorisation failed."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -5398,19 +3880,7 @@
             "value": "Authorization failed."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorization failed."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorization failed."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Authorization failed."
@@ -5420,18 +3890,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Falha na autorização."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Falha na autorização."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorization failed."
           }
         },
         "ru": {
@@ -5447,12 +3905,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การให้สิทธิ์ล้มเหลว"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "การให้สิทธิ์ล้มเหลว"
@@ -5500,12 +3952,6 @@
             "value": "Authorisation needs to be retried."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorisation needs to be retried."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -5530,34 +3976,10 @@
             "value": "Authorization needs to be retried."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorization needs to be retried."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorization needs to be retried."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "A autorização precisa ser tentada novamente. "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A autorização precisa ser tentada novamente. "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorization needs to be retried."
           }
         },
         "ru": {
@@ -5573,12 +3995,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ลองให้สิทธิ์อีกครั้ง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ลองให้สิทธิ์อีกครั้ง"
@@ -5626,12 +4042,6 @@
             "value": "Authorisation was cancelled by the user."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorisation was cancelled by the user."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -5662,19 +4072,7 @@
             "value": "Authorization was cancelled by the user."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorization was cancelled by the user."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorization was cancelled by the user."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Authorization was cancelled by the user."
@@ -5684,18 +4082,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "A autorização foi cancelada pelo usuário."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A autorização foi cancelada pelo usuário."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authorization was cancelled by the user."
           }
         },
         "ru": {
@@ -5711,12 +4097,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การอนุญาตถูกยกเลิกแล้วโดยผู้ใช้"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "การอนุญาตถูกยกเลิกแล้วโดยผู้ใช้"
@@ -5763,12 +4143,6 @@
             "value": "Available Offline"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Available Offline"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -5793,34 +4167,10 @@
             "value": "Available Offline"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Available Offline"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Available Offline"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Disponível Offline"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disponível Offline"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Available Offline"
           }
         },
         "ru": {
@@ -5836,12 +4186,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "พร้อมใช้งานแบบออฟไลน์แล้ว"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "พร้อมใช้งานแบบออฟไลน์แล้ว"
@@ -5883,12 +4227,6 @@
             "value": "Between {{min}} and {{max}} {{characterType}}"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Between {{min}} and {{max}} {{characterType}}"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -5913,30 +4251,6 @@
             "value": "Between {{min}} and {{max}} {{characterType}}"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Between {{min}} and {{max}} {{characterType}}"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Between {{min}} and {{max}} {{characterType}}"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Between {{min}} and {{max}} {{characterType}}"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Between {{min}} and {{max}} {{characterType}}"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -5944,12 +4258,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Between {{min}} and {{max}} {{characterType}}"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Between {{min}} and {{max}} {{characterType}}"
@@ -5997,12 +4305,6 @@
             "value": "Bookmark created with a newer app version. Please update the app."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bookmark created with a newer app version. Please update the app."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -6027,34 +4329,10 @@
             "value": "Bookmark created with a newer app version. Please update the app."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bookmark created with a newer app version. Please update the app."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bookmark created with a newer app version. Please update the app."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Marcador criado com uma versão mais recente do aplicativo. Atualize o aplicativo. "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Marcador criado com uma versão mais recente do aplicativo. Atualize o aplicativo. "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bookmark created with a newer app version. Please update the app."
           }
         },
         "ru": {
@@ -6070,12 +4348,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สร้างบุ๊กมาร์กด้วยแอปเวอร์ชันใหม่กว่า โปรดอัปเดตแอป"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "สร้างบุ๊กมาร์กด้วยแอปเวอร์ชันใหม่กว่า โปรดอัปเดตแอป"
@@ -6121,12 +4393,6 @@
             "value": "Can't build custom scheme URL from %@."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Can't build custom scheme URL from %@."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -6151,34 +4417,10 @@
             "value": "Can't build custom scheme URL from %@."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Can't build custom scheme URL from %@."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Can't build custom scheme URL from %@."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Não é possível criar URL de esquema personalizado de %@."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Não é possível criar URL de esquema personalizado de %@."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Can't build custom scheme URL from %@."
           }
         },
         "ru": {
@@ -6194,12 +4436,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Can't build custom scheme URL from %@."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Can't build custom scheme URL from %@."
@@ -6247,12 +4483,6 @@
             "value": "Can't open authorisation URL with custom scheme."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Can't open authorisation URL with custom scheme."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -6277,34 +4507,10 @@
             "value": "Can't open authorization URL with custom scheme."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Can't open authorization URL with custom scheme."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Can't open authorization URL with custom scheme."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Não é possível abrir o URL de autorização com esquema personalizado."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Não é possível abrir o URL de autorização com esquema personalizado."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Can't open authorization URL with custom scheme."
           }
         },
         "ru": {
@@ -6320,12 +4526,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Can't open authorization URL with custom scheme."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Can't open authorization URL with custom scheme."
@@ -6372,12 +4572,6 @@
             "value": "Can't open custom scheme URL %@."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Can't open custom scheme URL %@."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -6402,34 +4596,10 @@
             "value": "Can't open custom scheme URL %@."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Can't open custom scheme URL %@."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Can't open custom scheme URL %@."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Não é possível abrir o URL de esquema personalizado %@."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Não é possível abrir o URL de esquema personalizado %@."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Can't open custom scheme URL %@."
           }
         },
         "ru": {
@@ -6445,12 +4615,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Can't open custom scheme URL %@."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Can't open custom scheme URL %@."
@@ -6496,12 +4660,6 @@
             "value": "Cancel"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -6532,19 +4690,7 @@
             "value": "Cancel"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Cancel"
@@ -6554,18 +4700,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cancelar"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancelar"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel"
           }
         },
         "ru": {
@@ -6581,12 +4715,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ยกเลิก"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ยกเลิก"
@@ -6626,12 +4754,6 @@
             "value": "Certificate"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -6656,30 +4778,6 @@
             "value": "Certificate"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -6687,12 +4785,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Certificate"
@@ -6738,12 +4830,6 @@
             "value": "Certificate Date"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate Date"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -6768,34 +4854,10 @@
             "value": "Certificate Date"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate Date"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate Date"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Data do Certificado "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Data do Certificado "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate Date"
           }
         },
         "ru": {
@@ -6811,12 +4873,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "วันที่รับรอง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "วันที่รับรอง"
@@ -6863,12 +4919,6 @@
             "value": "Certificate changed"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate changed"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -6893,34 +4943,10 @@
             "value": "Certificate changed"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate changed"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate changed"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Certificado alterado "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificado alterado "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate changed"
           }
         },
         "ru": {
@@ -6936,12 +4962,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เปลี่ยนใบรับรองแล้ว"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "เปลี่ยนใบรับรองแล้ว"
@@ -6981,12 +5001,6 @@
             "value": "Certificate for %@ passed validation."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate for %@ passed validation."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -7011,30 +5025,6 @@
             "value": "Certificate for %@ passed validation."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate for %@ passed validation."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate for %@ passed validation."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate for %@ passed validation."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate for %@ passed validation."
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -7042,12 +5032,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate for %@ passed validation."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Certificate for %@ passed validation."
@@ -7087,12 +5071,6 @@
             "value": "Certificates"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificates"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -7117,30 +5095,6 @@
             "value": "Certificates"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificates"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificates"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificates"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificates"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -7148,12 +5102,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificates"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Certificates"
@@ -7199,12 +5147,6 @@
             "value": "Class"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Class"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -7229,34 +5171,10 @@
             "value": "Class"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Class"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Class"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Classe"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Classe"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Class"
           }
         },
         "ru": {
@@ -7272,12 +5190,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "หมวดหมู่"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "หมวดหมู่"
@@ -7325,12 +5237,6 @@
             "value": "Client registration failed."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Client registration failed."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -7355,34 +5261,10 @@
             "value": "Client registration failed."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Client registration failed."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Client registration failed."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "O registro do cliente falhou. "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O registro do cliente falhou. "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Client registration failed."
           }
         },
         "ru": {
@@ -7398,12 +5280,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การลงทะเบียนไคลเอนต์ล้มเหลว"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "การลงทะเบียนไคลเอนต์ล้มเหลว"
@@ -7449,12 +5325,6 @@
             "value": "Closing vault…"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Closing vault…"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -7479,34 +5349,10 @@
             "value": "Closing vault…"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Closing vault…"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Closing vault…"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Fechando cofre…"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fechando cofre…"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Closing vault…"
           }
         },
         "ru": {
@@ -7522,12 +5368,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Closing vault…"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Closing vault…"
@@ -7573,12 +5413,6 @@
             "value": "Connected"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connected"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -7609,19 +5443,7 @@
             "value": "Connected"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connected"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connected"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Connected"
@@ -7634,18 +5456,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ligado"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conectado"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Ligado"
@@ -7664,12 +5474,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เชื่อมต่อ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "เชื่อมต่อ"
@@ -7709,12 +5513,6 @@
             "value": "Connecting"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connecting"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -7739,30 +5537,6 @@
             "value": "Connecting"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connecting"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connecting"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connecting"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connecting"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -7770,12 +5544,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connecting"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Connecting"
@@ -7822,12 +5590,6 @@
             "value": "Connecting…"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connecting…"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -7858,19 +5620,7 @@
             "value": "Connecting…"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connecting…"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connecting…"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Connecting…"
@@ -7883,18 +5633,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A ligar..."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conectando..."
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "A ligar..."
@@ -7913,12 +5651,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กำลังเชื่อมต่อ..."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "กำลังเชื่อมต่อ..."
@@ -7958,12 +5690,6 @@
             "value": "Connection refused"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connection refused"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -7988,30 +5714,6 @@
             "value": "Connection refused"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connection refused"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connection refused"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connection refused"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connection refused"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -8019,12 +5721,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connection refused"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Connection refused"
@@ -8072,12 +5768,6 @@
             "value": "Connection validation failed."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connection validation failed."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -8102,34 +5792,10 @@
             "value": "Connection validation failed."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connection validation failed."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connection validation failed."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "A validação da conexão falhou. "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A validação da conexão falhou. "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connection validation failed."
           }
         },
         "ru": {
@@ -8145,12 +5811,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ตรวจสอบการเชื่อมต่อล้มเหลว"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ตรวจสอบการเชื่อมต่อล้มเหลว"
@@ -8198,12 +5858,6 @@
             "value": "Construction of URL Session Task failed."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Construction of URL Session Task failed."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -8234,19 +5888,7 @@
             "value": "Construction of URL Session Task failed."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Construction of URL Session Task failed."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Construction of URL Session Task failed."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Construction of URL Session Task failed."
@@ -8256,18 +5898,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "A construção da Tarefa de Sessão de URL falhou."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A construção da Tarefa de Sessão de URL falhou."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Construction of URL Session Task failed."
           }
         },
         "ru": {
@@ -8283,12 +5913,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การสร้าง URL งานเซสชันล้มเหลว"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "การสร้าง URL งานเซสชันล้มเหลว"
@@ -8334,12 +5958,6 @@
             "value": "Contributor"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contributor"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -8364,34 +5982,10 @@
             "value": "Contributor"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contributor"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contributor"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Contribuinte"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contribuinte"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contributor"
           }
         },
         "ru": {
@@ -8407,12 +6001,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contributor"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Contributor"
@@ -8458,12 +6046,6 @@
             "value": "Copying %@ to %@…"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copying %@ to %@…"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -8494,19 +6076,7 @@
             "value": "Copying %@ to %@…"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copying %@ to %@…"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copying %@ to %@…"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Copying %@ to %@…"
@@ -8516,18 +6086,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Copiando %@ para %@…"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copiando %@ para %@…"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copying %@ to %@…"
           }
         },
         "ru": {
@@ -8543,12 +6101,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กำลังคัดลอก %@ ไปยัง %@..."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "กำลังคัดลอก %@ ไปยัง %@..."
@@ -8594,12 +6146,6 @@
             "value": "Couldn't copy %@ to %@, because an item called %@ already exists there."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't copy %@ to %@, because an item called %@ already exists there."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -8630,19 +6176,7 @@
             "value": "Couldn't copy %@ to %@, because an item called %@ already exists there."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't copy %@ to %@, because an item called %@ already exists there."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't copy %@ to %@, because an item called %@ already exists there."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Couldn't copy %@ to %@, because an item called %@ already exists there."
@@ -8652,18 +6186,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Não foi possível copiar %@ para %@,porque um item chamado %@ já existe lá."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Não foi possível copiar %@ para %@,porque um item chamado %@ já existe lá."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't copy %@ to %@, because an item called %@ already exists there."
           }
         },
         "ru": {
@@ -8679,12 +6201,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่สามารถคัดลอก %@ ไปยัง %@ เนื่องจากรายการ %@ ถูกเรียกใช้อยู่"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไม่สามารถคัดลอก %@ ไปยัง %@ เนื่องจากรายการ %@ ถูกเรียกใช้อยู่"
@@ -8724,12 +6240,6 @@
             "value": "Couldn't create %@"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't create %@"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -8754,30 +6264,6 @@
             "value": "Couldn't create %@"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't create %@"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't create %@"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't create %@"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't create %@"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -8785,12 +6271,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't create %@"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Couldn't create %@"
@@ -8830,12 +6310,6 @@
             "value": "Couldn't delete %@"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't delete %@"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -8860,30 +6334,6 @@
             "value": "Couldn't delete %@"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't delete %@"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't delete %@"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't delete %@"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't delete %@"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -8891,12 +6341,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't delete %@"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Couldn't delete %@"
@@ -8942,12 +6386,6 @@
             "value": "Couldn't download %@"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't download %@"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -8972,34 +6410,10 @@
             "value": "Couldn't download %@"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't download %@"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't download %@"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Não foi possível baixar %@"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Não foi possível baixar %@"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't download %@"
           }
         },
         "ru": {
@@ -9015,12 +6429,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่สามารถดาวน์โหลด %@"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไม่สามารถดาวน์โหลด %@"
@@ -9066,12 +6474,6 @@
             "value": "Couldn't move %@ to %@, because an item called %@ already exists there."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't move %@ to %@, because an item called %@ already exists there."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -9102,19 +6504,7 @@
             "value": "Couldn't move %@ to %@, because an item called %@ already exists there."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't move %@ to %@, because an item called %@ already exists there."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't move %@ to %@, because an item called %@ already exists there."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Couldn't move %@ to %@, because an item called %@ already exists there."
@@ -9124,18 +6514,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Não foi possível mover %@ para %@, porque um item chamado %@ já existe lá."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Não foi possível mover %@ para %@, porque um item chamado %@ já existe lá."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't move %@ to %@, because an item called %@ already exists there."
           }
         },
         "ru": {
@@ -9151,12 +6529,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่สามารถย้าย %@ ไปยัง %@ เนื่องจากรายการ %@ มีอยู่แล้ว"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไม่สามารถย้าย %@ ไปยัง %@ เนื่องจากรายการ %@ มีอยู่แล้ว"
@@ -9202,12 +6574,6 @@
             "value": "Couldn't rename %@ to %@, because another item with that name already exists."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't rename %@ to %@, because another item with that name already exists."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -9232,34 +6598,10 @@
             "value": "Couldn't rename %@ to %@, because another item with that name already exists."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't rename %@ to %@, because another item with that name already exists."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't rename %@ to %@, because another item with that name already exists."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Não foi possível renomear %@ para %@ porque já existe outro item com esse nome."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Não foi possível renomear %@ para %@ porque já existe outro item com esse nome."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't rename %@ to %@, because another item with that name already exists."
           }
         },
         "ru": {
@@ -9275,12 +6617,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't rename %@ to %@, because another item with that name already exists."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Couldn't rename %@ to %@, because another item with that name already exists."
@@ -9320,12 +6656,6 @@
             "value": "Couldn't upload %@"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't upload %@"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -9350,30 +6680,6 @@
             "value": "Couldn't upload %@"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't upload %@"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't upload %@"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't upload %@"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't upload %@"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -9381,12 +6687,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't upload %@"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Couldn't upload %@"
@@ -9433,12 +6733,6 @@
             "value": "Creating folder %@…"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Creating folder %@…"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -9469,19 +6763,7 @@
             "value": "Creating folder %@…"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Creating folder %@…"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Creating folder %@…"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Creating folder %@…"
@@ -9491,18 +6773,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Criando a pasta %@…"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Criando a pasta %@…"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Creating folder %@…"
           }
         },
         "ru": {
@@ -9518,12 +6788,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กำลังสร้างโฟลเดอร์ %@..."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "กำลังสร้างโฟลเดอร์ %@..."
@@ -9563,12 +6827,6 @@
             "value": "Creating share for %@…"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Creating share for %@…"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -9593,30 +6851,6 @@
             "value": "Creating share for %@…"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Creating share for %@…"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Creating share for %@…"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Creating share for %@…"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Creating share for %@…"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -9624,12 +6858,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Creating share for %@…"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Creating share for %@…"
@@ -9675,12 +6903,6 @@
             "value": "Custom"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Custom"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -9705,34 +6927,10 @@
             "value": "Custom"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Custom"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Custom"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Personalizadas"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Personalizadas"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Custom"
           }
         },
         "ru": {
@@ -9748,12 +6946,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กำหนดเอง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "กำหนดเอง"
@@ -9799,12 +6991,6 @@
             "value": "Database Version"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Database Version"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -9829,34 +7015,10 @@
             "value": "Database Version"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Database Version"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Database Version"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Versão do Banco de Dados"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versão do Banco de Dados"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Database Version"
           }
         },
         "ru": {
@@ -9872,12 +7034,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เวอร์ชันฐานข้อมูล"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "เวอร์ชันฐานข้อมูล"
@@ -9923,12 +7079,6 @@
             "value": "Database size"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Database size"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -9953,34 +7103,10 @@
             "value": "Database size"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Database size"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Database size"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Tamanho do banco de dados "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tamanho do banco de dados "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Database size"
           }
         },
         "ru": {
@@ -9996,12 +7122,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ขนาดของฐานข้อมูล"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ขนาดของฐานข้อมูล"
@@ -10049,12 +7169,6 @@
             "value": "Database upgrade required. Please open the app to perform the upgrade."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Database upgrade required. Please open the app to perform the upgrade."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -10079,34 +7193,10 @@
             "value": "Database upgrade required. Please open the app to perform the upgrade."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Database upgrade required. Please open the app to perform the upgrade."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Database upgrade required. Please open the app to perform the upgrade."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "É necessário atualizar o banco de dados. Abra o aplicativo para realizar a atualização."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "É necessário atualizar o banco de dados. Abra o aplicativo para realizar a atualização."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Database upgrade required. Please open the app to perform the upgrade."
           }
         },
         "ru": {
@@ -10122,12 +7212,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "จำเป็นต้องอัปเกรดฐานข้อมูล โปรดเปิดแอปเพื่อทำการอัปเกรด"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "จำเป็นต้องอัปเกรดฐานข้อมูล โปรดเปิดแอปเพื่อทำการอัปเกรด"
@@ -10173,12 +7257,6 @@
             "value": "Delete"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -10209,19 +7287,7 @@
             "value": "Delete"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Delete"
@@ -10231,18 +7297,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Excluir"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Excluir"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete"
           }
         },
         "ru": {
@@ -10258,12 +7312,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ลบ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ลบ"
@@ -10309,12 +7357,6 @@
             "value": "Delete Authentication Data"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete Authentication Data"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -10339,34 +7381,10 @@
             "value": "Delete Authentication Data"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete Authentication Data"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete Authentication Data"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Excluir dados de autenticação"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Excluir dados de autenticação"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete Authentication Data"
           }
         },
         "ru": {
@@ -10382,12 +7400,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ลบข้อมูลการรับรองความถูกต้อง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ลบข้อมูลการรับรองความถูกต้อง"
@@ -10433,12 +7445,6 @@
             "value": "Delete Database"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete Database"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -10463,34 +7469,10 @@
             "value": "Delete Database"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete Database"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete Database"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Excluir Banco de Dados "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Excluir Banco de Dados "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete Database"
           }
         },
         "ru": {
@@ -10506,12 +7488,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ลบฐานข้อมูล"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ลบฐานข้อมูล"
@@ -10558,12 +7534,6 @@
             "value": "Deleting %@…"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deleting %@…"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -10594,19 +7564,7 @@
             "value": "Deleting %@…"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deleting %@…"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deleting %@…"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Deleting %@…"
@@ -10616,18 +7574,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Excluindo %@…"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Excluindo %@…"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deleting %@…"
           }
         },
         "ru": {
@@ -10643,12 +7589,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กำลังลบ %@..."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "กำลังลบ %@..."
@@ -10688,12 +7628,6 @@
             "value": "Deleting share for %@…"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deleting share for %@…"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -10718,30 +7652,6 @@
             "value": "Deleting share for %@…"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deleting share for %@…"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deleting share for %@…"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deleting share for %@…"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deleting share for %@…"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -10749,12 +7659,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deleting share for %@…"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Deleting share for %@…"
@@ -10800,12 +7704,6 @@
             "value": "Deschedule (remove)"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deschedule (remove)"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -10830,34 +7728,10 @@
             "value": "Deschedule (remove)"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deschedule (remove)"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deschedule (remove)"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Desmarcar (remover) "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desmarcar (remover) "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deschedule (remove)"
           }
         },
         "ru": {
@@ -10873,12 +7747,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ลบกำหนดการ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ลบกำหนดการ"
@@ -10924,12 +7792,6 @@
             "value": "Download and preview"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download and preview"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -10954,34 +7816,10 @@
             "value": "Download and preview"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download and preview"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download and preview"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Baixar e visualizar"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Baixar e visualizar"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download and preview"
           }
         },
         "ru": {
@@ -10997,12 +7835,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download and preview"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Download and preview"
@@ -11048,12 +7880,6 @@
             "value": "Download, preview and share"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download, preview and share"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -11078,34 +7904,10 @@
             "value": "Download, preview and share"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download, preview and share"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download, preview and share"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Baixe, visualize e compartilhe"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Baixe, visualize e compartilhe"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download, preview and share"
           }
         },
         "ru": {
@@ -11121,12 +7923,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download, preview and share"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Download, preview and share"
@@ -11173,12 +7969,6 @@
             "value": "Downloading %@…"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Downloading %@…"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -11209,19 +7999,7 @@
             "value": "Downloading %@…"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Downloading %@…"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Downloading %@…"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Downloading %@…"
@@ -11231,18 +8009,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Baixando %@…"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Baixando %@…"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Downloading %@…"
           }
         },
         "ru": {
@@ -11258,12 +8024,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กำลังดาวน์โหลด %@..."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "กำลังดาวน์โหลด %@..."
@@ -11309,12 +8069,6 @@
             "value": "Edit, download, preview and share"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Edit, download, preview and share"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -11339,34 +8093,10 @@
             "value": "Edit, download, preview and share"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Edit, download, preview and share"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Edit, download, preview and share"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Edite, baixe, visualize e compartilhe"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Edite, baixe, visualize e compartilhe"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Edit, download, preview and share"
           }
         },
         "ru": {
@@ -11382,12 +8112,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Edit, download, preview and share"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Edit, download, preview and share"
@@ -11433,12 +8157,6 @@
             "value": "Editor"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Editor"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -11463,31 +8181,7 @@
             "value": "Editor"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Editor"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Editor"
-          }
-        },
         "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Editor"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Editor"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Editor"
@@ -11506,12 +8200,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Editor"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Editor"
@@ -11557,12 +8245,6 @@
             "value": "Error"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -11593,19 +8275,7 @@
             "value": "Error"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Error"
@@ -11618,18 +8288,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erro"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erro"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Erro"
@@ -11648,12 +8306,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ข้อผิดพลาด"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ข้อผิดพลาด"
@@ -11699,12 +8351,6 @@
             "value": "Error copying %@"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error copying %@"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -11735,19 +8381,7 @@
             "value": "Error copying %@"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error copying %@"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error copying %@"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Error copying %@"
@@ -11757,18 +8391,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Erro ao copiar %@"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erro ao copiar %@"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error copying %@"
           }
         },
         "ru": {
@@ -11784,12 +8406,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เกิดข้อผิดพลาดขณะคัดลอก %@"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "เกิดข้อผิดพลาดขณะคัดลอก %@"
@@ -11829,12 +8445,6 @@
             "value": "Error deleting %@"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error deleting %@"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -11859,30 +8469,6 @@
             "value": "Error deleting %@"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error deleting %@"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error deleting %@"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error deleting %@"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error deleting %@"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -11890,12 +8476,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error deleting %@"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Error deleting %@"
@@ -11941,12 +8521,6 @@
             "value": "Error moving %@"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error moving %@"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -11977,19 +8551,7 @@
             "value": "Error moving %@"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error moving %@"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error moving %@"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Error moving %@"
@@ -11999,18 +8561,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Erro ao mover %@"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erro ao mover %@"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error moving %@"
           }
         },
         "ru": {
@@ -12026,12 +8576,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เกิดข้อผิดพลาดขณะย้าย %@"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "เกิดข้อผิดพลาดขณะย้าย %@"
@@ -12077,12 +8621,6 @@
             "value": "Error renaming %@"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error renaming %@"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -12107,34 +8645,10 @@
             "value": "Error renaming %@"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error renaming %@"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error renaming %@"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Erro ao renomear %@"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erro ao renomear %@"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error renaming %@"
           }
         },
         "ru": {
@@ -12150,12 +8664,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error renaming %@"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Error renaming %@"
@@ -12201,12 +8709,6 @@
             "value": "Error updating %@ metadata"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error updating %@ metadata"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -12237,19 +8739,7 @@
             "value": "Error updating %@ metadata"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error updating %@ metadata"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error updating %@ metadata"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Error updating %@ metadata"
@@ -12259,18 +8749,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Erro atualizando %@ metadados"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erro atualizando %@ metadados"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error updating %@ metadata"
           }
         },
         "ru": {
@@ -12286,12 +8764,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เกิดข้อผิดพลาดขณะอัปเดต metadata %@"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "เกิดข้อผิดพลาดขณะอัปเดต metadata %@"
@@ -12331,12 +8803,6 @@
             "value": "Error uploading %@"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error uploading %@"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -12361,30 +8827,6 @@
             "value": "Error uploading %@"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error uploading %@"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error uploading %@"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error uploading %@"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error uploading %@"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -12392,12 +8834,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error uploading %@"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Error uploading %@"
@@ -12443,12 +8879,6 @@
             "value": "Events"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Events"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -12473,34 +8903,10 @@
             "value": "Events"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Events"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Events"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Eventos"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eventos"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Events"
           }
         },
         "ru": {
@@ -12516,12 +8922,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เหตุการณ์"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "เหตุการณ์"
@@ -12567,12 +8967,6 @@
             "value": "Exception occured performing action"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exception occured performing action"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -12597,34 +8991,10 @@
             "value": "Exception occured performing action"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exception occured performing action"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exception occured performing action"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Ocorreu uma exceção ao executar a ação"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ocorreu uma exceção ao executar a ação"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exception occured performing action"
           }
         },
         "ru": {
@@ -12640,12 +9010,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exception occured performing action"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Exception occured performing action"
@@ -12691,12 +9055,6 @@
             "value": "Failed"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -12721,34 +9079,10 @@
             "value": "Failed"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Falhou"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Falhou"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed"
           }
         },
         "ru": {
@@ -12764,12 +9098,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ล้มเหลว"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ล้มเหลว"
@@ -12815,12 +9143,6 @@
             "value": "Fetching updates…"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fetching updates…"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -12845,34 +9167,10 @@
             "value": "Fetching updates…"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fetching updates…"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fetching updates…"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Buscando Atualizações… "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buscando Atualizações… "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fetching updates…"
           }
         },
         "ru": {
@@ -12888,12 +9186,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กำลังเรียกอัปเดตข้อมูล..."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "กำลังเรียกอัปเดตข้อมูล..."
@@ -12939,12 +9231,6 @@
             "value": "Fetching user information…"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fetching user information…"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -12975,19 +9261,7 @@
             "value": "Fetching user information…"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fetching user information…"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fetching user information…"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Fetching user information…"
@@ -13000,18 +9274,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A obter a informação do utilizador..."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buscando informações do usuário..."
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "A obter a informação do utilizador..."
@@ -13030,12 +9292,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กำลังเรียกข้อมูลผู้ใช้..."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "กำลังเรียกข้อมูลผู้ใช้..."
@@ -13075,12 +9331,6 @@
             "value": "File"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "File"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -13105,30 +9355,6 @@
             "value": "File"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "File"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "File"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "File"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "File"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -13136,12 +9362,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "File"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "File"
@@ -13187,12 +9407,6 @@
             "value": "File modified locally"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "File modified locally"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -13217,34 +9431,10 @@
             "value": "File modified locally"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "File modified locally"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "File modified locally"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Arquivo modificado localmente "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Arquivo modificado localmente "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "File modified locally"
           }
         },
         "ru": {
@@ -13260,12 +9450,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไฟล์ที่ถูกแก้ไขในเครื่อง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไฟล์ที่ถูกแก้ไขในเครื่อง"
@@ -13313,12 +9497,6 @@
             "value": "File not found."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "File not found."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -13343,34 +9521,10 @@
             "value": "File not found."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "File not found."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "File not found."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Arquivo não encontrado."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Arquivo não encontrado."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "File not found."
           }
         },
         "ru": {
@@ -13386,12 +9540,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่พบไฟล์"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไม่พบไฟล์"
@@ -13438,12 +9586,6 @@
             "value": "Files"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Files"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -13468,34 +9610,10 @@
             "value": "Files"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Files"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Files"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Arquivos"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Arquivos"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Files"
           }
         },
         "ru": {
@@ -13511,12 +9629,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไฟล์"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไฟล์"
@@ -13562,12 +9674,6 @@
             "value": "Folders"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Folders"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -13592,34 +9698,10 @@
             "value": "Folders"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Folders"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Folders"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Pastas"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pastas"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Folders"
           }
         },
         "ru": {
@@ -13635,12 +9717,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สร้างโฟลเดอร์ใหม่"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "สร้างโฟลเดอร์ใหม่"
@@ -13688,12 +9764,6 @@
             "value": "Generic graph error."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Generic graph error."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -13718,34 +9788,10 @@
             "value": "Generic graph error."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Generic graph error."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Generic graph error."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Erro gráfico genérico."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erro gráfico genérico."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Generic graph error."
           }
         },
         "ru": {
@@ -13761,12 +9807,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Generic graph error."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Generic graph error."
@@ -13812,12 +9852,6 @@
             "value": "Identifier"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Identifier"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -13842,34 +9876,10 @@
             "value": "Identifier"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Identifier"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Identifier"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Identificador "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Identificador "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Identifier"
           }
         },
         "ru": {
@@ -13885,12 +9895,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ระบุ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ระบุ"
@@ -13936,12 +9940,6 @@
             "value": "In progress since"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "In progress since"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -13966,34 +9964,10 @@
             "value": "In progress since"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "In progress since"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "In progress since"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Em andamento desde "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Em andamento desde "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "In progress since"
           }
         },
         "ru": {
@@ -14009,12 +9983,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "อยู่ระหว่างดำเนินการตั้งแต่"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "อยู่ระหว่างดำเนินการตั้งแต่"
@@ -14061,12 +10029,6 @@
             "value": "Insecure HTTP URL"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Insecure HTTP URL"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -14091,34 +10053,10 @@
             "value": "Insecure HTTP URL"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Insecure HTTP URL"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Insecure HTTP URL"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "HTTP URL Inseguro"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "HTTP URL Inseguro"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Insecure HTTP URL"
           }
         },
         "ru": {
@@ -14134,12 +10072,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "URL ที่เชื่อมต่อผ่าน HTTP ไม่ปลอดภัย"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "URL ที่เชื่อมต่อผ่าน HTTP ไม่ปลอดภัย"
@@ -14185,12 +10117,6 @@
             "value": "Insecure HTTP URL forbidden"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Insecure HTTP URL forbidden"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -14215,34 +10141,10 @@
             "value": "Insecure HTTP URL forbidden"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Insecure HTTP URL forbidden"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Insecure HTTP URL forbidden"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "HTTP inseguro URL proibida"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "HTTP inseguro URL proibida"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Insecure HTTP URL forbidden"
           }
         },
         "ru": {
@@ -14258,12 +10160,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ห้ามใช้ URL HTTP ที่ไม่ปลอดภัย"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ห้ามใช้ URL HTTP ที่ไม่ปลอดภัย"
@@ -14311,12 +10207,6 @@
             "value": "Insufficient parameters."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Insufficient parameters."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -14347,19 +10237,7 @@
             "value": "Insufficient parameters."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Insufficient parameters."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Insufficient parameters."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Insufficient parameters."
@@ -14369,18 +10247,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Parâmetros insuficientes."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Parâmetros insuficientes."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Insufficient parameters."
           }
         },
         "ru": {
@@ -14396,12 +10262,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "พารามิเตอร์ไม่เพียงพอ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "พารามิเตอร์ไม่เพียงพอ"
@@ -14447,12 +10307,6 @@
             "value": "Insufficient permissions"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Insufficient permissions"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -14483,19 +10337,7 @@
             "value": "Insufficient permissions"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Insufficient permissions"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Insufficient permissions"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Insufficient permissions"
@@ -14505,18 +10347,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Permissões insuficientes"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permissões insuficientes"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Insufficient permissions"
           }
         },
         "ru": {
@@ -14532,12 +10362,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สิทธิ์ไม่เพียงพอ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "สิทธิ์ไม่เพียงพอ"
@@ -14585,12 +10409,6 @@
             "value": "Internal error."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Internal error."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -14621,19 +10439,7 @@
             "value": "Internal error."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Internal error."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Internal error."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Internal error."
@@ -14643,18 +10449,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Erro interno."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erro interno."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Internal error."
           }
         },
         "ru": {
@@ -14670,12 +10464,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ข้อผิดพลาดภายใน"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ข้อผิดพลาดภายใน"
@@ -14721,12 +10509,6 @@
             "value": "Invalid checksum"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid checksum"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -14751,34 +10533,10 @@
             "value": "Invalid checksum"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid checksum"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid checksum"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Checksum inválido "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Checksum inválido "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid checksum"
           }
         },
         "ru": {
@@ -14794,12 +10552,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การตรวจสอบไม่ถูกต้อง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "การตรวจสอบไม่ถูกต้อง"
@@ -14847,12 +10599,6 @@
             "value": "Invalid parameter."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid parameter."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -14877,34 +10623,10 @@
             "value": "Invalid parameter."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid parameter."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid parameter."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Parâmetro inválido."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Parâmetro inválido."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid parameter."
           }
         },
         "ru": {
@@ -14920,12 +10642,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid parameter."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Invalid parameter."
@@ -14966,12 +10682,6 @@
             "value": "Invalid rule without minimum and maximum count"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid rule without minimum and maximum count"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -14996,30 +10706,6 @@
             "value": "Invalid rule without minimum and maximum count"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid rule without minimum and maximum count"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid rule without minimum and maximum count"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid rule without minimum and maximum count"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid rule without minimum and maximum count"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -15027,12 +10713,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid rule without minimum and maximum count"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Invalid rule without minimum and maximum count"
@@ -15080,12 +10760,6 @@
             "value": "Invalid type."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid type."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -15110,34 +10784,10 @@
             "value": "Invalid type."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid type."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid type."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Tipo inválido."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tipo inválido."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid type."
           }
         },
         "ru": {
@@ -15153,12 +10803,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid type."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Invalid type."
@@ -15198,12 +10842,6 @@
             "value": "Invalidate"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalidate"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -15228,30 +10866,6 @@
             "value": "Invalidate"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalidate"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalidate"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalidate"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalidate"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -15259,12 +10873,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalidate"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Invalidate"
@@ -15310,12 +10918,6 @@
             "value": "Invalidate Login Data"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalidate Login Data"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -15340,34 +10942,10 @@
             "value": "Invalidate Login Data"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalidate Login Data"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalidate Login Data"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "needs_review",
             "value": "Dados de Login Inválidos "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dados de Login Inválidos "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalidate Login Data"
           }
         },
         "ru": {
@@ -15385,12 +10963,6 @@
         "th-TH": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "ข้อมูลการเข้าสู่ระบบไม่ถูกต้อง"
-          }
-        },
-        "th_TH": {
-          "stringUnit": {
-            "state": "translated",
             "value": "ข้อมูลการเข้าสู่ระบบไม่ถูกต้อง"
           }
         },
@@ -15435,12 +11007,6 @@
             "value": "Invited persons"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invited persons"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -15465,34 +11031,10 @@
             "value": "Invited persons"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invited persons"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invited persons"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Pessoas convidadas"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pessoas convidadas"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invited persons"
           }
         },
         "ru": {
@@ -15508,12 +11050,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invited persons"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Invited persons"
@@ -15553,12 +11089,6 @@
             "value": "Issues were found while validating the certificate for %@."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Issues were found while validating the certificate for %@."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -15583,30 +11113,6 @@
             "value": "Issues were found while validating the certificate for %@."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Issues were found while validating the certificate for %@."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Issues were found while validating the certificate for %@."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Issues were found while validating the certificate for %@."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Issues were found while validating the certificate for %@."
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -15614,12 +11120,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Issues were found while validating the certificate for %@."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Issues were found while validating the certificate for %@."
@@ -15659,12 +11159,6 @@
             "value": "Item"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -15689,30 +11183,6 @@
             "value": "Item"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -15720,12 +11190,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Item"
@@ -15773,12 +11237,6 @@
             "value": "Item is currently processing."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item is currently processing."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -15803,34 +11261,10 @@
             "value": "Item is currently processing."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item is currently processing."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item is currently processing."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "O item está sendo processado no momento."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O item está sendo processado no momento."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item is currently processing."
           }
         },
         "ru": {
@@ -15846,12 +11280,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item is currently processing."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Item is currently processing."
@@ -15899,12 +11327,6 @@
             "value": "Item is not a directory."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item is not a directory."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -15929,34 +11351,10 @@
             "value": "Item is not a directory."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item is not a directory."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item is not a directory."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "O item não é um diretório."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O item não é um diretório."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item is not a directory."
           }
         },
         "ru": {
@@ -15972,12 +11370,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "รายการไม่ใช่ไดเร็กทอรี"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "รายการไม่ใช่ไดเร็กทอรี"
@@ -16025,12 +11417,6 @@
             "value": "Item not available offline."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item not available offline."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -16055,34 +11441,10 @@
             "value": "Item not available offline."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item not available offline."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item not available offline."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Item não disponível quando desconectado."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item não disponível quando desconectado."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item not available offline."
           }
         },
         "ru": {
@@ -16098,12 +11460,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "รายการไม่พร้อมใช้งานในโหมดออฟไลน์"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "รายการไม่พร้อมใช้งานในโหมดออฟไลน์"
@@ -16151,12 +11507,6 @@
             "value": "Item not found."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item not found."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -16181,34 +11531,10 @@
             "value": "Item not found."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item not found."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item not found."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Item não encontrado."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item não encontrado."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Item not found."
           }
         },
         "ru": {
@@ -16224,12 +11550,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่พบรายการ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไม่พบรายการ"
@@ -16275,12 +11595,6 @@
             "value": "Keep both"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keep both"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -16305,34 +11619,10 @@
             "value": "Keep both"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keep both"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keep both"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Manter ambos"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Manter ambos"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keep both"
           }
         },
         "ru": {
@@ -16348,12 +11638,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เก็บไว้ทั้งสองอย่าง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "เก็บไว้ทั้งสองอย่าง"
@@ -16399,12 +11683,6 @@
             "value": "Lane ID"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lane ID"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -16429,34 +11707,10 @@
             "value": "Lane ID"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lane ID"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lane ID"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "ID da pista "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ID da pista "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lane ID"
           }
         },
         "ru": {
@@ -16472,12 +11726,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lane ID"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Lane ID"
@@ -16523,12 +11771,6 @@
             "value": "Local ID"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Local ID"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -16553,34 +11795,10 @@
             "value": "Local ID"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Local ID"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Local ID"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "ID local "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ID local "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Local ID"
           }
         },
         "ru": {
@@ -16596,12 +11814,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Local ID"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Local ID"
@@ -16647,12 +11859,6 @@
             "value": "Localised Description"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Localised Description"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -16677,34 +11883,10 @@
             "value": "Localized Description"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Localized Description"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Localized Description"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Descrição Localizada "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Descrição Localizada "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Localized Description"
           }
         },
         "ru": {
@@ -16720,12 +11902,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "คำอธิบายที่แปลเป็นภาษาท้องถิ่น"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "คำอธิบายที่แปลเป็นภาษาท้องถิ่น"
@@ -16773,12 +11949,6 @@
             "value": "Lock invalidated."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lock invalidated."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -16803,34 +11973,10 @@
             "value": "Lock invalidated."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lock invalidated."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lock invalidated."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Bloqueio invalidado."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bloqueio invalidado."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lock invalidated."
           }
         },
         "ru": {
@@ -16846,12 +11992,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lock invalidated."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Lock invalidated."
@@ -16897,12 +12037,6 @@
             "value": "Log HTTP requests and responses"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Log HTTP requests and responses"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -16927,34 +12061,10 @@
             "value": "Log HTTP requests and responses"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Log HTTP requests and responses"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Log HTTP requests and responses"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Registrar solicitações e respostas HTTP"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Registrar solicitações e respostas HTTP"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Log HTTP requests and responses"
           }
         },
         "ru": {
@@ -16970,12 +12080,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "บันทึกคำขอและการตอบกลับ HTTP"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "บันทึกคำขอและการตอบกลับ HTTP"
@@ -17021,12 +12125,6 @@
             "value": "Log file"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Log file"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -17057,19 +12155,7 @@
             "value": "Log file"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Log file"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Log file"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Log file"
@@ -17079,18 +12165,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Arquivo de Log"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Arquivo de Log"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Log file"
           }
         },
         "ru": {
@@ -17106,12 +12180,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไฟล์ log"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไฟล์ log"
@@ -17157,12 +12225,6 @@
             "value": "Log internal file operations"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Log internal file operations"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -17187,34 +12249,10 @@
             "value": "Log internal file operations"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Log internal file operations"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Log internal file operations"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Registrar operações de arquivo interno"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Registrar operações de arquivo interno"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Log internal file operations"
           }
         },
         "ru": {
@@ -17230,12 +12268,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Log การทำงานของไฟล์ภายใน"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Log การทำงานของไฟล์ภายใน"
@@ -17281,12 +12313,6 @@
             "value": "Login as user %@ required. Please retry."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Login as user %@ required. Please retry."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -17311,34 +12337,10 @@
             "value": "Login as user %@ required. Please retry."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Login as user %@ required. Please retry."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Login as user %@ required. Please retry."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "É necessário fazer login como usuário %@ .  Por favor tente novamente."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "É necessário fazer login como usuário %@ .  Por favor tente novamente."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Login as user %@ required. Please retry."
           }
         },
         "ru": {
@@ -17354,12 +12356,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กรุณาเข้าสู่ระบบด้วยฐานะ %@ โปรดลองอีกครั้ง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "กรุณาเข้าสู่ระบบด้วยฐานะ %@ โปรดลองอีกครั้ง"
@@ -17400,12 +12396,6 @@
             "value": "Longer than {{byteLength}} bytes in {{encoding}} encoding."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Longer than {{byteLength}} bytes in {{encoding}} encoding."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -17430,30 +12420,6 @@
             "value": "Longer than {{byteLength}} bytes in {{encoding}} encoding."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Longer than {{byteLength}} bytes in {{encoding}} encoding."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Longer than {{byteLength}} bytes in {{encoding}} encoding."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Longer than {{byteLength}} bytes in {{encoding}} encoding."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Longer than {{byteLength}} bytes in {{encoding}} encoding."
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -17461,12 +12427,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Longer than {{byteLength}} bytes in {{encoding}} encoding."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Longer than {{byteLength}} bytes in {{encoding}} encoding."
@@ -17506,12 +12466,6 @@
             "value": "Making %1$@ available offline also covers %2$@, which was previously requested as being available offline."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Making %1$@ available offline also covers %2$@, which was previously requested as being available offline."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -17536,30 +12490,6 @@
             "value": "Making %1$@ available offline also covers %2$@, which was previously requested as being available offline."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Making %1$@ available offline also covers %2$@, which was previously requested as being available offline."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Making %1$@ available offline also covers %2$@, which was previously requested as being available offline."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Making %1$@ available offline also covers %2$@, which was previously requested as being available offline."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Making %1$@ available offline also covers %2$@, which was previously requested as being available offline."
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -17567,12 +12497,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Making %1$@ available offline also covers %2$@, which was previously requested as being available offline."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Making %1$@ available offline also covers %2$@, which was previously requested as being available offline."
@@ -17612,12 +12536,6 @@
             "value": "Making %1$@ available offline also covers %2$@, whose offline availability has previously been requested."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Making %1$@ available offline also covers %2$@, whose offline availability has previously been requested."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -17642,30 +12560,6 @@
             "value": "Making %1$@ available offline also covers %2$@, whose offline availability has previously been requested."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Making %1$@ available offline also covers %2$@, whose offline availability has previously been requested."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Making %1$@ available offline also covers %2$@, whose offline availability has previously been requested."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Making %1$@ available offline also covers %2$@, whose offline availability has previously been requested."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Making %1$@ available offline also covers %2$@, whose offline availability has previously been requested."
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -17673,12 +12567,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Making %1$@ available offline also covers %2$@, whose offline availability has previously been requested."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Making %1$@ available offline also covers %2$@, whose offline availability has previously been requested."
@@ -17724,12 +12612,6 @@
             "value": "Manager"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Manager"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -17754,34 +12636,10 @@
             "value": "Manager"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Manager"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Manager"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Gerente"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gerente"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Manager"
           }
         },
         "ru": {
@@ -17797,12 +12655,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Manager"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Manager"
@@ -17850,12 +12702,6 @@
             "value": "Missing Drive ID."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Missing Drive ID."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -17880,34 +12726,10 @@
             "value": "Missing Drive ID."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Missing Drive ID."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Missing Drive ID."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "ID da unidade ausente."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ID da unidade ausente."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Missing Drive ID."
           }
         },
         "ru": {
@@ -17923,12 +12745,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Missing Drive ID."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Missing Drive ID."
@@ -17974,12 +12790,6 @@
             "value": "Moving %@ to %@…"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Moving %@ to %@…"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -18010,19 +12820,7 @@
             "value": "Moving %@ to %@…"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Moving %@ to %@…"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Moving %@ to %@…"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Moving %@ to %@…"
@@ -18032,18 +12830,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Movendo %@ para %@…"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Movendo %@ para %@…"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Moving %@ to %@…"
           }
         },
         "ru": {
@@ -18059,12 +12845,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กำลังย้าย %@ ไปยัง %@..."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "กำลังย้าย %@ ไปยัง %@..."
@@ -18110,12 +12890,6 @@
             "value": "Name"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Name"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -18140,34 +12914,10 @@
             "value": "Name"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Name"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Name"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Nome"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nome"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Name"
           }
         },
         "ru": {
@@ -18183,12 +12933,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ชื่อ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ชื่อ"
@@ -18234,12 +12978,6 @@
             "value": "Network unavailable"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Network unavailable"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -18264,34 +13002,10 @@
             "value": "Network unavailable"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Network unavailable"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Network unavailable"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Rede indisponível"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rede indisponível"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Network unavailable"
           }
         },
         "ru": {
@@ -18307,12 +13021,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เครือข่ายใช้งานไม่ได้"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "เครือข่ายใช้งานไม่ได้"
@@ -18360,12 +13068,6 @@
             "value": "No certificate was returned for a request despite this being a HTTPS connection (should never occur in production, but only if you forgot to provide a certificate during simulated responses to HTTPS requests)."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No certificate was returned for a request despite this being a HTTPS connection (should never occur in production, but only if you forgot to provide a certificate during simulated responses to HTTPS requests)."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -18396,19 +13098,7 @@
             "value": "No certificate was returned for a request despite this being a HTTPS connection (should never occur in production, but only if you forgot to provide a certificate during simulated responses to HTTPS requests)."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No certificate was returned for a request despite this being a HTTPS connection (should never occur in production, but only if you forgot to provide a certificate during simulated responses to HTTPS requests)."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No certificate was returned for a request despite this being a HTTPS connection (should never occur in production, but only if you forgot to provide a certificate during simulated responses to HTTPS requests)."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "No certificate was returned for a request despite this being a HTTPS connection (should never occur in production, but only if you forgot to provide a certificate during simulated responses to HTTPS requests)."
@@ -18418,18 +13108,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Nenhum certificado foi retornado para uma solicitação, apesar de esta ser uma conexão HTTPS (nunca deve ocorrer em produção, mas somente se você esqueceu de fornecer um certificado durante respostas simuladas a solicitações HTTPS)."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nenhum certificado foi retornado para uma solicitação, apesar de esta ser uma conexão HTTPS (nunca deve ocorrer em produção, mas somente se você esqueceu de fornecer um certificado durante respostas simuladas a solicitações HTTPS)."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No certificate was returned for a request despite this being a HTTPS connection (should never occur in production, but only if you forgot to provide a certificate during simulated responses to HTTPS requests)."
           }
         },
         "ru": {
@@ -18445,12 +13123,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่มีการส่งคืนใบรับรองสำหรับคำขอแม้ว่าจะเป็นการเชื่อมต่อแบบ HTTPS (คุณอาจจะลืมระบุใบรับรองในระหว่างการตอบกลับคำขอของ HTTPS)"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไม่มีการส่งคืนใบรับรองสำหรับคำขอแม้ว่าจะเป็นการเชื่อมต่อแบบ HTTPS (คุณอาจจะลืมระบุใบรับรองในระหว่างการตอบกลับคำขอของ HTTPS)"
@@ -18498,12 +13170,6 @@
             "value": "No data converter available for conversion."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No data converter available for conversion."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -18528,34 +13194,10 @@
             "value": "No data converter available for conversion."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No data converter available for conversion."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No data converter available for conversion."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Nenhum conversor de dados disponível para conversão."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nenhum conversor de dados disponível para conversão."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No data converter available for conversion."
           }
         },
         "ru": {
@@ -18571,12 +13213,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No data converter available for conversion."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "No data converter available for conversion."
@@ -18624,12 +13260,6 @@
             "value": "Not authorised to access shares."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Not authorised to access shares."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -18654,34 +13284,10 @@
             "value": "Not authorized to access shares."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Not authorized to access shares."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Not authorized to access shares."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Não autorizado a acessar compartilhamentos."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Não autorizado a acessar compartilhamentos."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Not authorized to access shares."
           }
         },
         "ru": {
@@ -18697,12 +13303,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่ได้รับอนุญาตให้เข้าถึงแชร์"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไม่ได้รับอนุญาตให้เข้าถึงแชร์"
@@ -18750,12 +13350,6 @@
             "value": "Not available offline."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Not available offline."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -18780,34 +13374,10 @@
             "value": "Not available offline."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Not available offline."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Not available offline."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Não disponível quando desconectado. "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Não disponível quando desconectado. "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Not available offline."
           }
         },
         "ru": {
@@ -18823,12 +13393,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่สามารถใช้งานออฟไลน์ได้"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไม่สามารถใช้งานออฟไลน์ได้"
@@ -18874,12 +13438,6 @@
             "value": "Not enough space left on the server to upload %@."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Not enough space left on the server to upload %@."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -18904,34 +13462,10 @@
             "value": "Not enough space left on the server to upload %@."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Not enough space left on the server to upload %@."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Not enough space left on the server to upload %@."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Não há espaço suficiente no servidor para fazer o envio de  %@."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Não há espaço suficiente no servidor para fazer o envio de  %@."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Not enough space left on the server to upload %@."
           }
         },
         "ru": {
@@ -18947,12 +13481,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "พื้นที่เหลือบนเซิร์ฟเวอร์ไม่เพียงพอที่จะอัปโหลดไฟล์ %@"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "พื้นที่เหลือบนเซิร์ฟเวอร์ไม่เพียงพอที่จะอัปโหลดไฟล์ %@"
@@ -18998,12 +13526,6 @@
             "value": "OK"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -19034,37 +13556,13 @@
             "value": "OK"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
-          }
-        },
         "nn-NO": {
           "stringUnit": {
             "state": "translated",
             "value": "OK"
           }
         },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
-          }
-        },
         "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "OK"
@@ -19083,12 +13581,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ตกลง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ตกลง"
@@ -19136,12 +13628,6 @@
             "value": "Object does not return DataItemType."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Object does not return DataItemType."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -19166,34 +13652,10 @@
             "value": "Object does not return DataItemType."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Object does not return DataItemType."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Object does not return DataItemType."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "O objeto não retorna DataItemType."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O objeto não retorna DataItemType."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Object does not return DataItemType."
           }
         },
         "ru": {
@@ -19209,12 +13671,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Object does not return DataItemType."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Object does not return DataItemType."
@@ -19261,12 +13717,6 @@
             "value": "Offline"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Offline"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -19291,34 +13741,10 @@
             "value": "Offline"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Offline"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Offline"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Desconectado"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desconectado"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Offline"
           }
         },
         "ru": {
@@ -19334,12 +13760,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ออฟไลน์"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ออฟไลน์"
@@ -19386,12 +13806,6 @@
             "value": "Offline (no WiFi connection)"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Offline (no WiFi connection)"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -19416,34 +13830,10 @@
             "value": "Offline (no WiFi connection)"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Offline (no WiFi connection)"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Offline (no WiFi connection)"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Desconectado (sem conexão WiFi)"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desconectado (sem conexão WiFi)"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Offline (no WiFi connection)"
           }
         },
         "ru": {
@@ -19459,12 +13849,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ออฟไลน์ (ไม่มีการเชื่อมต่อWiFi)"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ออฟไลน์ (ไม่มีการเชื่อมต่อWiFi)"
@@ -19505,12 +13889,6 @@
             "value": "Offline availability of %1$@ is already ensured by having made %2$@ available offline."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Offline availability of %1$@ is already ensured by having made %2$@ available offline."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -19535,30 +13913,6 @@
             "value": "Offline availability of %1$@ is already ensured by having made %2$@ available offline."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Offline availability of %1$@ is already ensured by having made %2$@ available offline."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Offline availability of %1$@ is already ensured by having made %2$@ available offline."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Offline availability of %1$@ is already ensured by having made %2$@ available offline."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Offline availability of %1$@ is already ensured by having made %2$@ available offline."
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -19566,12 +13920,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Offline availability of %1$@ is already ensured by having made %2$@ available offline."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Offline availability of %1$@ is already ensured by having made %2$@ available offline."
@@ -19618,12 +13966,6 @@
             "value": "Online"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Online"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -19648,34 +13990,10 @@
             "value": "Online"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Online"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Online"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Conectado"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conectado"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Online"
           }
         },
         "ru": {
@@ -19691,12 +14009,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ออนไลน์"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ออนไลน์"
@@ -19742,12 +14054,6 @@
             "value": "Only invited persons have access. Login required."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Only invited persons have access. Login required."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -19772,34 +14078,10 @@
             "value": "Only invited persons have access. Login required."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Only invited persons have access. Login required."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Only invited persons have access. Login required."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Apenas pessoas convidadas têm acesso. Login é necessário."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apenas pessoas convidadas têm acesso. Login é necessário."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Only invited persons have access. Login required."
           }
         },
         "ru": {
@@ -19815,12 +14097,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Only invited persons have access. Login required."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Only invited persons have access. Login required."
@@ -19860,12 +14136,6 @@
             "value": "Opening vault…"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Opening vault…"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -19890,30 +14160,6 @@
             "value": "Opening vault…"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Opening vault…"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Opening vault…"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Opening vault…"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Opening vault…"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -19921,12 +14167,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Opening vault…"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Opening vault…"
@@ -19973,12 +14213,6 @@
             "value": "Operation forbidden"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Operation forbidden"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -20009,19 +14243,7 @@
             "value": "Operation forbidden"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Operation forbidden"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Operation forbidden"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Operation forbidden"
@@ -20031,18 +14253,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Operação proibida"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Operação proibida"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Operation forbidden"
           }
         },
         "ru": {
@@ -20058,12 +14268,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "หยุดการทำงาน"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "หยุดการทำงาน"
@@ -20109,12 +14313,6 @@
             "value": "Origin Process"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Origin Process"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -20139,34 +14337,10 @@
             "value": "Origin Process"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Origin Process"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Origin Process"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Processo de Origem "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Processo de Origem "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Origin Process"
           }
         },
         "ru": {
@@ -20182,12 +14356,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กระบวนการกำเนิด"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "กระบวนการกำเนิด"
@@ -20233,12 +14401,6 @@
             "value": "Origin Process Valid"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Origin Process Valid"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -20263,34 +14425,10 @@
             "value": "Origin Process Valid"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Origin Process Valid"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Origin Process Valid"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Processo de origem válido "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Processo de origem válido "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Origin Process Valid"
           }
         },
         "ru": {
@@ -20306,12 +14444,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กระบวนการกำเนิดที่ถูกต้อง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "กระบวนการกำเนิดที่ถูกต้อง"
@@ -20357,12 +14489,6 @@
             "value": "Origin URL"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Origin URL"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -20387,34 +14513,10 @@
             "value": "Origin URL"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Origin URL"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Origin URL"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "URL de origem "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "URL de origem "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Origin URL"
           }
         },
         "ru": {
@@ -20430,12 +14532,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "URL ต้นทาง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "URL ต้นทาง"
@@ -20483,12 +14579,6 @@
             "value": "Other item policies of the same kind covering subsets of this item policy become redundant by the addition of this item policy."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Other item policies of the same kind covering subsets of this item policy become redundant by the addition of this item policy."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -20513,34 +14603,10 @@
             "value": "Other item policies of the same kind covering subsets of this item policy become redundant by the addition of this item policy."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Other item policies of the same kind covering subsets of this item policy become redundant by the addition of this item policy."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Other item policies of the same kind covering subsets of this item policy become redundant by the addition of this item policy."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Outras políticas de itens do mesmo tipo, cobrindo subconjuntos desta política de itens, tornam-se redundantes com a adição desta política de itens. "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Outras políticas de itens do mesmo tipo, cobrindo subconjuntos desta política de itens, tornam-se redundantes com a adição desta política de itens. "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Other item policies of the same kind covering subsets of this item policy become redundant by the addition of this item policy."
           }
         },
         "ru": {
@@ -20556,12 +14622,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "นโยบายรายการซ้ำกับนโยบายมีอยู่แล้ว ทำให้ไม่สามารถเพิ่มนโยบาย"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "นโยบายรายการซ้ำกับนโยบายมีอยู่แล้ว ทำให้ไม่สามารถเพิ่มนโยบาย"
@@ -20601,12 +14661,6 @@
             "value": "Overwrite modified file"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Overwrite modified file"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -20631,30 +14685,6 @@
             "value": "Overwrite modified file"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Overwrite modified file"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Overwrite modified file"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Overwrite modified file"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Overwrite modified file"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -20662,12 +14692,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Overwrite modified file"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Overwrite modified file"
@@ -20709,12 +14733,6 @@
             "value": "Password can't be converted to {{encoding}}."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Password can't be converted to {{encoding}}."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -20739,30 +14757,6 @@
             "value": "Password can't be converted to {{encoding}}."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Password can't be converted to {{encoding}}."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Password can't be converted to {{encoding}}."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Password can't be converted to {{encoding}}."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Password can't be converted to {{encoding}}."
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -20770,12 +14764,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Password can't be converted to {{encoding}}."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Password can't be converted to {{encoding}}."
@@ -20822,12 +14810,6 @@
             "value": "Pending"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pending"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -20852,34 +14834,10 @@
             "value": "Pending"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pending"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pending"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Pendente"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pendente"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pending"
           }
         },
         "ru": {
@@ -20895,12 +14853,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "อยู่ระหว่างดำเนินการ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "อยู่ระหว่างดำเนินการ"
@@ -20947,12 +14899,6 @@
             "value": "Personal"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Personal"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -20977,34 +14923,10 @@
             "value": "Personal"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Personal"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Personal"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Pessoal"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pessoal"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Personal"
           }
         },
         "ru": {
@@ -21020,12 +14942,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ส่วนตัว"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ส่วนตัว"
@@ -21071,12 +14987,6 @@
             "value": "Please check if you have sufficient permissions to delete %@."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Please check if you have sufficient permissions to delete %@."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -21107,19 +15017,7 @@
             "value": "Please check if you have sufficient permissions to delete %@."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Please check if you have sufficient permissions to delete %@."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Please check if you have sufficient permissions to delete %@."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Please check if you have sufficient permissions to delete %@."
@@ -21129,18 +15027,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Por favor, verifique se você tem permissões suficientes para excluir %@."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Por favor, verifique se você tem permissões suficientes para excluir %@."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Please check if you have sufficient permissions to delete %@."
           }
         },
         "ru": {
@@ -21156,12 +15042,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "โปรดตรวจสอบว่าคุณมีสิทธิ์เพียงพอที่จะลบ %@"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "โปรดตรวจสอบว่าคุณมีสิทธิ์เพียงพอที่จะลบ %@"
@@ -21208,12 +15088,6 @@
             "value": "Populating database…"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Populating database…"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -21238,34 +15112,10 @@
             "value": "Populating database…"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Populating database…"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Populating database…"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Preenchendo o banco de dados..."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Preenchendo o banco de dados..."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Populating database…"
           }
         },
         "ru": {
@@ -21281,12 +15131,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Populating database…"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Populating database…"
@@ -21332,12 +15176,6 @@
             "value": "Previous token refresh attempts indicated an invalid refresh token."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Previous token refresh attempts indicated an invalid refresh token."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -21362,34 +15200,10 @@
             "value": "Previous token refresh attempts indicated an invalid refresh token."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Previous token refresh attempts indicated an invalid refresh token."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Previous token refresh attempts indicated an invalid refresh token."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Tentativas anteriores de atualização de token indicaram um token de atualização inválido."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tentativas anteriores de atualização de token indicaram um token de atualização inválido."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Previous token refresh attempts indicated an invalid refresh token."
           }
         },
         "ru": {
@@ -21405,12 +15219,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Previous token refresh attempts indicated an invalid refresh token."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Previous token refresh attempts indicated an invalid refresh token."
@@ -21458,12 +15266,6 @@
             "value": "Private link format invalid."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Private link format invalid."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -21488,34 +15290,10 @@
             "value": "Private link format invalid."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Private link format invalid."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Private link format invalid."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Formato de linque privado inválido. "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Formato de linque privado inválido. "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Private link format invalid."
           }
         },
         "ru": {
@@ -21531,12 +15309,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "รูปแบบลิงก์ส่วนตัวไม่ถูกต้อง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "รูปแบบลิงก์ส่วนตัวไม่ถูกต้อง"
@@ -21583,12 +15355,6 @@
             "value": "Proceed"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proceed"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -21619,19 +15385,7 @@
             "value": "Proceed"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proceed"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proceed"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Proceed"
@@ -21641,18 +15395,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Prosseguir"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prosseguir"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proceed"
           }
         },
         "ru": {
@@ -21668,12 +15410,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ดำเนินการ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ดำเนินการ"
@@ -21719,12 +15455,6 @@
             "value": "Process Sync Records"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Process Sync Records"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -21749,34 +15479,10 @@
             "value": "Process Sync Records"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Process Sync Records"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Process Sync Records"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Registros de Sincronização de Processo "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Registros de Sincronização de Processo "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Process Sync Records"
           }
         },
         "ru": {
@@ -21792,12 +15498,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ประมวลผลบันทึกการซิงค์"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ประมวลผลบันทึกการซิงค์"
@@ -21845,12 +15545,6 @@
             "value": "Public upload was disabled by the administrator."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Public upload was disabled by the administrator."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -21875,34 +15569,10 @@
             "value": "Public upload was disabled by the administrator."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Public upload was disabled by the administrator."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Public upload was disabled by the administrator."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "O envio de arquivo público foi desativado pelo administrador."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O envio de arquivo público foi desativado pelo administrador."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Public upload was disabled by the administrator."
           }
         },
         "ru": {
@@ -21918,12 +15588,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การอัปโหลดสาธารณะถูกปิดใช้งานโดยผู้ดูแลระบบ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "การอัปโหลดสาธารณะถูกปิดใช้งานโดยผู้ดูแลระบบ"
@@ -21969,12 +15633,6 @@
             "value": "Recipients can upload but existing contents are not revealed."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recipients can upload but existing contents are not revealed."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -21999,34 +15657,10 @@
             "value": "Recipients can upload but existing contents are not revealed."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recipients can upload but existing contents are not revealed."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recipients can upload but existing contents are not revealed."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Os destinatários podem fazer upload, mas os conteúdos existentes não são revelados."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Os destinatários podem fazer upload, mas os conteúdos existentes não são revelados."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recipients can upload but existing contents are not revealed."
           }
         },
         "ru": {
@@ -22042,12 +15676,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recipients can upload but existing contents are not revealed."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Recipients can upload but existing contents are not revealed."
@@ -22093,12 +15721,6 @@
             "value": "Recipients can view and download contents."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recipients can view and download contents."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -22123,34 +15745,10 @@
             "value": "Recipients can view and download contents."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recipients can view and download contents."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recipients can view and download contents."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Os destinatários podem visualizar e baixar o conteúdo."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Os destinatários podem visualizar e baixar o conteúdo."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recipients can view and download contents."
           }
         },
         "ru": {
@@ -22166,12 +15764,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recipients can view and download contents."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Recipients can view and download contents."
@@ -22217,12 +15809,6 @@
             "value": "Recipients can view, download and edit contents."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recipients can view, download and edit contents."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -22247,34 +15833,10 @@
             "value": "Recipients can view, download and edit contents."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recipients can view, download and edit contents."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recipients can view, download and edit contents."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Os destinatários podem visualizar, baixar e editar o conteúdo."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Os destinatários podem visualizar, baixar e editar o conteúdo."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recipients can view, download and edit contents."
           }
         },
         "ru": {
@@ -22290,12 +15852,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ผู้รับสามารถดู ดาวน์โหลด และแก้ไขเนื้อหา"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ผู้รับสามารถดู ดาวน์โหลด และแก้ไขเนื้อหา"
@@ -22341,12 +15897,6 @@
             "value": "Recipients can view, download and upload contents."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recipients can view, download and upload contents."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -22371,34 +15921,10 @@
             "value": "Recipients can view, download and upload contents."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recipients can view, download and upload contents."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recipients can view, download and upload contents."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Os destinatários podem visualizar, baixar e fazer upload de conteúdo."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Os destinatários podem visualizar, baixar e fazer upload de conteúdo."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recipients can view, download and upload contents."
           }
         },
         "ru": {
@@ -22414,12 +15940,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ผู้รับสามารถดู ดาวน์โหลด และอัปโหลดเนื้อหา"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ผู้รับสามารถดู ดาวน์โหลด และอัปโหลดเนื้อหา"
@@ -22465,12 +15985,6 @@
             "value": "Recipients can view, download, edit, delete and upload contents."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recipients can view, download, edit, delete and upload contents."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -22495,34 +16009,10 @@
             "value": "Recipients can view, download, edit, delete and upload contents."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recipients can view, download, edit, delete and upload contents."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recipients can view, download, edit, delete and upload contents."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Os destinatários podem visualizar, baixar, editar, excluir e enviar conteúdos."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Os destinatários podem visualizar, baixar, editar, excluir e enviar conteúdos."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recipients can view, download, edit, delete and upload contents."
           }
         },
         "ru": {
@@ -22538,12 +16028,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ผู้รับสามารถดู ดาวน์โหลด แก้ไข ลบและอัปโหลดเนื้อหา"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ผู้รับสามารถดู ดาวน์โหลด แก้ไข ลบและอัปโหลดเนื้อหา"
@@ -22583,12 +16067,6 @@
             "value": "Redirection"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Redirection"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -22613,30 +16091,6 @@
             "value": "Redirection"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Redirection"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Redirection"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Redirection"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Redirection"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -22644,12 +16098,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Redirection"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Redirection"
@@ -22689,12 +16137,6 @@
             "value": "Rejecting share…"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rejecting share…"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -22719,30 +16161,6 @@
             "value": "Rejecting share…"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rejecting share…"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rejecting share…"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rejecting share…"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rejecting share…"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -22750,12 +16168,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rejecting share…"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Rejecting share…"
@@ -22801,12 +16213,6 @@
             "value": "Remove Database Version"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remove Database Version"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -22831,34 +16237,10 @@
             "value": "Remove Database Version"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remove Database Version"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remove Database Version"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Remover Versão do Banco de Dados "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remover Versão do Banco de Dados "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remove Database Version"
           }
         },
         "ru": {
@@ -22874,12 +16256,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ลบเวอร์ชันฐานข้อมูล"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ลบเวอร์ชันฐานข้อมูล"
@@ -22925,12 +16301,6 @@
             "value": "Removed Items"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Removed Items"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -22955,34 +16325,10 @@
             "value": "Removed Items"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Removed Items"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Removed Items"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Itens Removidos "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Itens Removidos "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Removed Items"
           }
         },
         "ru": {
@@ -22998,12 +16344,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "รายการถูกลบแล้ว"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "รายการถูกลบแล้ว"
@@ -23043,12 +16383,6 @@
             "value": "Removing local copy of %@…"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Removing local copy of %@…"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -23073,30 +16407,6 @@
             "value": "Removing local copy of %@…"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Removing local copy of %@…"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Removing local copy of %@…"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Removing local copy of %@…"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Removing local copy of %@…"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -23104,12 +16414,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Removing local copy of %@…"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Removing local copy of %@…"
@@ -23155,12 +16459,6 @@
             "value": "Renaming %@ to %@…"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Renaming %@ to %@…"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -23191,19 +16489,7 @@
             "value": "Renaming %@ to %@…"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Renaming %@ to %@…"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Renaming %@ to %@…"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Renaming %@ to %@…"
@@ -23213,18 +16499,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Renomeando %@ para %@…"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Renomeando %@ para %@…"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Renaming %@ to %@…"
           }
         },
         "ru": {
@@ -23240,12 +16514,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กำลังเปลี่ยนชื่อ %@ เป็น %@..."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "กำลังเปลี่ยนชื่อ %@ เป็น %@..."
@@ -23291,12 +16559,6 @@
             "value": "Replace"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Replace"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -23321,34 +16583,10 @@
             "value": "Replace"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Replace"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Replace"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Substituir "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Substituir "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Replace"
           }
         },
         "ru": {
@@ -23364,12 +16602,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "แทนที่"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "แทนที่"
@@ -23417,12 +16649,6 @@
             "value": "Request completed with error."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request completed with error."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -23453,19 +16679,7 @@
             "value": "Request completed with error."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request completed with error."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request completed with error."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Request completed with error."
@@ -23475,18 +16689,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Solicitação concluída com erro."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Solicitação concluída com erro."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request completed with error."
           }
         },
         "ru": {
@@ -23502,12 +16704,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "คำขอเสร็จสิ้นแต่มีข้อผิดพลาดเกิดขึ้น"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "คำขอเสร็จสิ้นแต่มีข้อผิดพลาดเกิดขึ้น"
@@ -23555,12 +16751,6 @@
             "value": "Request couldn't be scheduled because the underlying URL session has been invalidated."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request couldn't be scheduled because the underlying URL session has been invalidated."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -23591,19 +16781,7 @@
             "value": "Request couldn't be scheduled because the underlying URL session has been invalidated."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request couldn't be scheduled because the underlying URL session has been invalidated."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request couldn't be scheduled because the underlying URL session has been invalidated."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Request couldn't be scheduled because the underlying URL session has been invalidated."
@@ -23613,18 +16791,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "A solicitação não pôde ser agendada porque a sessão de URL subjacente foi invalidada."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A solicitação não pôde ser agendada porque a sessão de URL subjacente foi invalidada."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request couldn't be scheduled because the underlying URL session has been invalidated."
           }
         },
         "ru": {
@@ -23640,12 +16806,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่สามารถกำหนดเวลาคำขอได้เนื่องจากเซสชัน URL พื้นฐานนั้นไม่ถูกต้อง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไม่สามารถกำหนดเวลาคำขอได้เนื่องจากเซสชัน URL พื้นฐานนั้นไม่ถูกต้อง"
@@ -23693,12 +16853,6 @@
             "value": "Request timed out"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request timed out"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -23723,34 +16877,10 @@
             "value": "Request timed out"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request timed out"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request timed out"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Solicitação expirou"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Solicitação expirou"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request timed out"
           }
         },
         "ru": {
@@ -23766,12 +16896,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การร้องขอหมดเวลา"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "การร้องขอหมดเวลา"
@@ -23819,12 +16943,6 @@
             "value": "Request was cancelled because the server certificate was rejected."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request was cancelled because the server certificate was rejected."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -23855,19 +16973,7 @@
             "value": "Request was cancelled because the server certificate was rejected."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request was cancelled because the server certificate was rejected."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request was cancelled because the server certificate was rejected."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Request was cancelled because the server certificate was rejected."
@@ -23877,18 +16983,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "A solicitação foi cancelada porque o certificado do servidor foi rejeitado."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A solicitação foi cancelada porque o certificado do servidor foi rejeitado."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request was cancelled because the server certificate was rejected."
           }
         },
         "ru": {
@@ -23904,12 +16998,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "คำขอถูกยกเลิกเนื่องจากใบรับรองเซิร์ฟเวอร์ถูกปฏิเสธ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "คำขอถูกยกเลิกเนื่องจากใบรับรองเซิร์ฟเวอร์ถูกปฏิเสธ"
@@ -23957,12 +17045,6 @@
             "value": "Request was cancelled."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request was cancelled."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -23993,19 +17075,7 @@
             "value": "Request was cancelled."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request was cancelled."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request was cancelled."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Request was cancelled."
@@ -24015,18 +17085,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Pedido cancelado."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pedido cancelado."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request was cancelled."
           }
         },
         "ru": {
@@ -24042,12 +17100,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "คำขอถูกยกเลิก"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "คำขอถูกยกเลิก"
@@ -24095,12 +17147,6 @@
             "value": "Request was dropped by the NSURLSession."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request was dropped by the NSURLSession."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -24131,19 +17177,7 @@
             "value": "Request was dropped by the NSURLSession."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request was dropped by the NSURLSession."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request was dropped by the NSURLSession."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Request was dropped by the NSURLSession."
@@ -24153,18 +17187,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "A solicitação foi descartada pela NSURLSession."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A solicitação foi descartada pela NSURLSession."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request was dropped by the NSURLSession."
           }
         },
         "ru": {
@@ -24180,12 +17202,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "คำร้องขอถูกยกเลิกแล้วโดย NSURLSession"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "คำร้องขอถูกยกเลิกแล้วโดย NSURLSession"
@@ -24233,12 +17249,6 @@
             "value": "Request was removed before scheduling."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request was removed before scheduling."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -24269,19 +17279,7 @@
             "value": "Request was removed before scheduling."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request was removed before scheduling."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request was removed before scheduling."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Request was removed before scheduling."
@@ -24291,18 +17289,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "A solicitação foi removida antes do agendamento."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A solicitação foi removida antes do agendamento."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request was removed before scheduling."
           }
         },
         "ru": {
@@ -24318,12 +17304,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "คำขอถูกลบออกก่อนกำหนดเวลา"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "คำขอถูกลบออกก่อนกำหนดเวลา"
@@ -24371,12 +17351,6 @@
             "value": "Required value missing."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Required value missing."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -24401,34 +17375,10 @@
             "value": "Required value missing."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Required value missing."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Required value missing."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Valor obrigatório ausente."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Valor obrigatório ausente."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Required value missing."
           }
         },
         "ru": {
@@ -24444,12 +17394,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Required value missing."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Required value missing."
@@ -24496,12 +17440,6 @@
             "value": "Reschedule"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reschedule"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -24526,34 +17464,10 @@
             "value": "Reschedule"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reschedule"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reschedule"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Reprogramar "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reprogramar "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reschedule"
           }
         },
         "ru": {
@@ -24569,12 +17483,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กำหนดเวลาใหม่"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "กำหนดเวลาใหม่"
@@ -24622,12 +17530,6 @@
             "value": "Resolution of private link failed."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resolution of private link failed."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -24652,34 +17554,10 @@
             "value": "Resolution of private link failed."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resolution of private link failed."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resolution of private link failed."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "A resolução do linque privado falhou. "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A resolução do linque privado falhou. "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resolution of private link failed."
           }
         },
         "ru": {
@@ -24695,12 +17573,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การแก้ไขลิงก์ส่วนตัวล้มเหลว"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "การแก้ไขลิงก์ส่วนตัวล้มเหลว"
@@ -24748,12 +17620,6 @@
             "value": "Resource does not exist."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resource does not exist."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -24778,34 +17644,10 @@
             "value": "Resource does not exist."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resource does not exist."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resource does not exist."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "O recurso não existe."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O recurso não existe."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resource does not exist."
           }
         },
         "ru": {
@@ -24821,12 +17663,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resource does not exist."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Resource does not exist."
@@ -24874,12 +17710,6 @@
             "value": "Resource not found."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resource not found."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -24904,34 +17734,10 @@
             "value": "Resource not found."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resource not found."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resource not found."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Recurso não encontrado. "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recurso não encontrado. "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resource not found."
           }
         },
         "ru": {
@@ -24947,12 +17753,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่พบทรัพยากร"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไม่พบทรัพยากร"
@@ -25000,12 +17800,6 @@
             "value": "Response was in an unknown format."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Response was in an unknown format."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -25036,19 +17830,7 @@
             "value": "Response was in an unknown format."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Response was in an unknown format."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Response was in an unknown format."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Response was in an unknown format."
@@ -25058,18 +17840,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "A resposta estava em um formato desconhecido."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A resposta estava em um formato desconhecido."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Response was in an unknown format."
           }
         },
         "ru": {
@@ -25085,12 +17855,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "มีการตอบสนองในรูปแบบที่ไม่รู้จัก"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "มีการตอบสนองในรูปแบบที่ไม่รู้จัก"
@@ -25130,12 +17894,6 @@
             "value": "Retrieving capabilities…"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retrieving capabilities…"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -25160,30 +17918,6 @@
             "value": "Retrieving capabilities…"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retrieving capabilities…"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retrieving capabilities…"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retrieving capabilities…"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retrieving capabilities…"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -25191,12 +17925,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retrieving capabilities…"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Retrieving capabilities…"
@@ -25243,12 +17971,6 @@
             "value": "Retrieving file list for %@…"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retrieving file list for %@…"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -25279,19 +18001,7 @@
             "value": "Retrieving file list for %@…"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retrieving file list for %@…"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retrieving file list for %@…"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Retrieving file list for %@…"
@@ -25301,18 +18011,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Recuperando lista de arquivos para %@…"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recuperando lista de arquivos para %@…"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retrieving file list for %@…"
           }
         },
         "ru": {
@@ -25328,12 +18026,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กำลังเรียกดูรายการไฟล์สำหรับ %@..."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "กำลังเรียกดูรายการไฟล์สำหรับ %@..."
@@ -25379,12 +18071,6 @@
             "value": "Retrieving items for %@"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retrieving items for %@"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -25409,34 +18095,10 @@
             "value": "Retrieving items for %@"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retrieving items for %@"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retrieving items for %@"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Recuperando itens para  %@"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recuperando itens para  %@"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retrieving items for %@"
           }
         },
         "ru": {
@@ -25452,12 +18114,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กำลังดึงรายการสำหรับ %@"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "กำลังดึงรายการสำหรับ %@"
@@ -25497,12 +18153,6 @@
             "value": "Retrieving metadata…"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retrieving metadata…"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -25527,30 +18177,6 @@
             "value": "Retrieving metadata…"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retrieving metadata…"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retrieving metadata…"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retrieving metadata…"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retrieving metadata…"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -25558,12 +18184,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retrieving metadata…"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Retrieving metadata…"
@@ -25609,12 +18229,6 @@
             "value": "Retry"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retry"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -25639,34 +18253,10 @@
             "value": "Retry"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retry"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retry"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Repetir"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Repetir"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retry"
           }
         },
         "ru": {
@@ -25682,12 +18272,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ลองใหม่อีกครั้ง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ลองใหม่อีกครั้ง"
@@ -25733,12 +18317,6 @@
             "value": "Running"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Running"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -25763,34 +18341,10 @@
             "value": "Running"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Running"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Running"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Executando"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Executando"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Running"
           }
         },
         "ru": {
@@ -25806,12 +18360,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กำลังรัน"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "กำลังรัน"
@@ -25857,12 +18405,6 @@
             "value": "Scheduled folder scans"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scheduled folder scans"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -25887,34 +18429,10 @@
             "value": "Scheduled folder scans"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scheduled folder scans"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scheduled folder scans"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Verificações programadas de pasta"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verificações programadas de pasta"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scheduled folder scans"
           }
         },
         "ru": {
@@ -25930,12 +18448,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สแกนโฟลเดอร์กำหนดการแล้ว"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "สแกนโฟลเดอร์กำหนดการแล้ว"
@@ -25983,12 +18495,6 @@
             "value": "Server detection failed because of too many redirects."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server detection failed because of too many redirects."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -26019,19 +18525,7 @@
             "value": "Server detection failed because of too many redirects."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server detection failed because of too many redirects."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server detection failed because of too many redirects."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Server detection failed because of too many redirects."
@@ -26041,18 +18535,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "A detecção do servidor falhou devido a muitos redirecionamentos."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A detecção do servidor falhou devido a muitos redirecionamentos."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server detection failed because of too many redirects."
           }
         },
         "ru": {
@@ -26068,12 +18550,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การตรวจหาเซิร์ฟเวอร์ล้มเหลวเนื่องจากมีการเปลี่ยนเส้นทางมากเกินไป"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "การตรวจหาเซิร์ฟเวอร์ล้มเหลวเนื่องจากมีการเปลี่ยนเส้นทางมากเกินไป"
@@ -26121,12 +18597,6 @@
             "value": "Server detection failed, i.e. when the server at a URL is not an ownCloud instance."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server detection failed, i.e. when the server at a URL is not an ownCloud instance."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -26157,19 +18627,7 @@
             "value": "Server detection failed, i.e. when the server at a URL is not an ownCloud instance."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server detection failed, i.e. when the server at a URL is not an ownCloud instance."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server detection failed, i.e. when the server at a URL is not an ownCloud instance."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Server detection failed, i.e. when the server at a URL is not an ownCloud instance."
@@ -26179,18 +18637,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "A detecção do servidor falhou, ou seja, quando o servidor em uma URL não é uma instância do ownCloud."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A detecção do servidor falhou, ou seja, quando o servidor em uma URL não é uma instância do ownCloud."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server detection failed, i.e. when the server at a URL is not an ownCloud instance."
           }
         },
         "ru": {
@@ -26206,12 +18652,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การตรวจหาเซิร์ฟเวอร์ล้มเหลวเช่น เมื่อใช้ URL ของเซิร์ฟเวอร์ที่ไม่ใช่อินสแตนซ์ของ ownCloud"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "การตรวจหาเซิร์ฟเวอร์ล้มเหลวเช่น เมื่อใช้ URL ของเซิร์ฟเวอร์ที่ไม่ใช่อินสแตนซ์ของ ownCloud"
@@ -26258,12 +18698,6 @@
             "value": "Server doesn't seem to support any authentication method supported by this app."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server doesn't seem to support any authentication method supported by this app."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -26294,19 +18728,7 @@
             "value": "Server doesn't seem to support any authentication method supported by this app."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server doesn't seem to support any authentication method supported by this app."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server doesn't seem to support any authentication method supported by this app."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Server doesn't seem to support any authentication method supported by this app."
@@ -26316,18 +18738,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "O servidor não parece suportar nenhum método de autenticação suportado por este aplicativo."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O servidor não parece suportar nenhum método de autenticação suportado por este aplicativo."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server doesn't seem to support any authentication method supported by this app."
           }
         },
         "ru": {
@@ -26343,12 +18753,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เซิร์ฟเวอร์ดูเหมือนจะไม่รองรับวิธีการรับรองความถูกต้องใดๆ ที่แอปนี้สนับสนุน"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "เซิร์ฟเวอร์ดูเหมือนจะไม่รองรับวิธีการรับรองความถูกต้องใดๆ ที่แอปนี้สนับสนุน"
@@ -26394,12 +18798,6 @@
             "value": "Server down for maintenance"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server down for maintenance"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -26424,34 +18822,10 @@
             "value": "Server down for maintenance"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server down for maintenance"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server down for maintenance"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Servidor inativo para manutenção"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Servidor inativo para manutenção"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server down for maintenance"
           }
         },
         "ru": {
@@ -26467,12 +18841,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เซิร์ฟเวอร์กำลังอยู่ในช่วงปิดปรับปรุง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "เซิร์ฟเวอร์กำลังอยู่ในช่วงปิดปรับปรุง"
@@ -26520,12 +18888,6 @@
             "value": "Server down for maintenance."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server down for maintenance."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -26556,19 +18918,7 @@
             "value": "Server down for maintenance."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server down for maintenance."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server down for maintenance."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Server down for maintenance."
@@ -26578,18 +18928,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Servidor desativado para manutenção."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Servidor desativado para manutenção."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server down for maintenance."
           }
         },
         "ru": {
@@ -26605,12 +18943,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เซิร์ฟเวอร์กำลังอยู่ในช่วงปิดปรับปรุง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "เซิร์ฟเวอร์กำลังอยู่ในช่วงปิดปรับปรุง"
@@ -26658,12 +18990,6 @@
             "value": "Server redirection to bad/invalid URL."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server redirection to bad/invalid URL."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -26694,19 +19020,7 @@
             "value": "Server redirection to bad/invalid URL."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server redirection to bad/invalid URL."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server redirection to bad/invalid URL."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Server redirection to bad/invalid URL."
@@ -26716,18 +19030,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Redirecionamento de servidor para URL errado/inválido."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Redirecionamento de servidor para URL errado/inválido."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server redirection to bad/invalid URL."
           }
         },
         "ru": {
@@ -26743,12 +19045,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เซิร์ฟเวอร์เปลี่ยนเส้นทางไปยัง URL ที่ไม่ถูกต้อง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "เซิร์ฟเวอร์เปลี่ยนเส้นทางไปยัง URL ที่ไม่ถูกต้อง"
@@ -26794,12 +19090,6 @@
             "value": "Server returns status %ld"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server returns status %ld"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -26824,34 +19114,10 @@
             "value": "Server returns status %ld"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server returns status %ld"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server returns status %ld"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "O servidor retorna ao status  %ld"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O servidor retorna ao status  %ld"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server returns status %ld"
           }
         },
         "ru": {
@@ -26867,12 +19133,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เซิร์ฟเวอร์ตอบกลับสถานะ %ld"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "เซิร์ฟเวอร์ตอบกลับสถานะ %ld"
@@ -26912,12 +19172,6 @@
             "value": "Server software %@ not supported."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server software %@ not supported."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -26942,30 +19196,6 @@
             "value": "Server software %@ not supported."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server software %@ not supported."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server software %@ not supported."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server software %@ not supported."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server software %@ not supported."
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -26973,12 +19203,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Server software %@ not supported."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Server software %@ not supported."
@@ -27024,12 +19248,6 @@
             "value": "Set detailed permissions"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Set detailed permissions"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -27054,34 +19272,10 @@
             "value": "Set detailed permissions"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Set detailed permissions"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Set detailed permissions"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Definir permissões detalhadas"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Definir permissões detalhadas"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Set detailed permissions"
           }
         },
         "ru": {
@@ -27097,12 +19291,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Set detailed permissions"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Set detailed permissions"
@@ -27150,12 +19338,6 @@
             "value": "Share not found."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Share not found."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -27180,34 +19362,10 @@
             "value": "Share not found."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Share not found."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Share not found."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Compartilhamento não encontrado."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Compartilhamento não encontrado."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Share not found."
           }
         },
         "ru": {
@@ -27223,12 +19381,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่พบการแชร์"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไม่พบการแชร์"
@@ -27274,12 +19426,6 @@
             "value": "Shared with me"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shared with me"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -27304,34 +19450,10 @@
             "value": "Shared with me"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shared with me"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shared with me"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Compartilhou comigo"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Compartilhou comigo"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shared with me"
           }
         },
         "ru": {
@@ -27347,12 +19469,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shared with me"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Shared with me"
@@ -27399,12 +19515,6 @@
             "value": "Shares"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shares"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -27429,34 +19539,10 @@
             "value": "Shares"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shares"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shares"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Compartilhamentos"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Compartilhamentos"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shares"
           }
         },
         "ru": {
@@ -27472,12 +19558,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "แชร์"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "แชร์"
@@ -27525,12 +19605,6 @@
             "value": "Shares are unavailable."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shares are unavailable."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -27555,34 +19629,10 @@
             "value": "Shares are unavailable."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shares are unavailable."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shares are unavailable."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Os compartilhamentos não estão indisponíveis."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Os compartilhamentos não estão indisponíveis."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shares are unavailable."
           }
         },
         "ru": {
@@ -27598,12 +19648,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "แชร์ไม่พร้อมใช้งาน"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "แชร์ไม่พร้อมใช้งาน"
@@ -27650,12 +19694,6 @@
             "value": "Sharing requires an active connection."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sharing requires an active connection."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -27680,34 +19718,10 @@
             "value": "Sharing requires an active connection."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sharing requires an active connection."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sharing requires an active connection."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "O compartilhamento requer uma conexão ativa."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O compartilhamento requer uma conexão ativa."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sharing requires an active connection."
           }
         },
         "ru": {
@@ -27723,12 +19737,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sharing requires an active connection."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Sharing requires an active connection."
@@ -27775,12 +19783,6 @@
             "value": "Standard error output"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Standard error output"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -27811,19 +19813,7 @@
             "value": "Standard error output"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Standard error output"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Standard error output"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Standard error output"
@@ -27833,18 +19823,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Saída de erro padrão"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Saída de erro padrão"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Standard error output"
           }
         },
         "ru": {
@@ -27860,12 +19838,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ข้อมูลข้อผิดพลาดมาตรฐาน"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ข้อมูลข้อผิดพลาดมาตรฐาน"
@@ -27911,12 +19883,6 @@
             "value": "State"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "State"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -27941,34 +19907,10 @@
             "value": "State"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "State"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "State"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Estado"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estado"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "State"
           }
         },
         "ru": {
@@ -27984,12 +19926,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สถานะ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "สถานะ"
@@ -28035,12 +19971,6 @@
             "value": "Sync Record ID"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sync Record ID"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -28065,34 +19995,10 @@
             "value": "Sync Record ID"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sync Record ID"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sync Record ID"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "ID de registro de sincronização "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ID de registro de sincronização "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sync Record ID"
           }
         },
         "ru": {
@@ -28108,12 +20014,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sync Record ID"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Sync Record ID"
@@ -28159,12 +20059,6 @@
             "value": "The URL you provided uses the HTTP rather than the HTTPS scheme, so your communication would not be encrypted."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The URL you provided uses the HTTP rather than the HTTPS scheme, so your communication would not be encrypted."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -28189,34 +20083,10 @@
             "value": "The URL you provided uses the HTTP rather than the HTTPS scheme, so your communication would not be encrypted."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The URL you provided uses the HTTP rather than the HTTPS scheme, so your communication would not be encrypted."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The URL you provided uses the HTTP rather than the HTTPS scheme, so your communication would not be encrypted."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "O URL que você forneceu usa o esquema HTTP, e não o HTTPS, logo sua comunicação não será criptografada."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O URL que você forneceu usa o esquema HTTP, e não o HTTPS, logo sua comunicação não será criptografada."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The URL you provided uses the HTTP rather than the HTTPS scheme, so your communication would not be encrypted."
           }
         },
         "ru": {
@@ -28232,12 +20102,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "คถุณกำลังใช้งาน URL HTTP แทนที่จะเป็นรูปแบบ HTTPS ดังนั้นการสื่อสารของคุณจะไม่ถูกเข้ารหัส"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "คถุณกำลังใช้งาน URL HTTP แทนที่จะเป็นรูปแบบ HTTPS ดังนั้นการสื่อสารของคุณจะไม่ถูกเข้ารหัส"
@@ -28283,12 +20147,6 @@
             "value": "The URL you provided uses the HTTP rather than the HTTPS scheme. If you continue, your communication will not be encrypted."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The URL you provided uses the HTTP rather than the HTTPS scheme. If you continue, your communication will not be encrypted."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -28313,34 +20171,10 @@
             "value": "The URL you provided uses the HTTP rather than the HTTPS scheme. If you continue, your communication will not be encrypted."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The URL you provided uses the HTTP rather than the HTTPS scheme. If you continue, your communication will not be encrypted."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The URL you provided uses the HTTP rather than the HTTPS scheme. If you continue, your communication will not be encrypted."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "O URL fornecido por você usa o HTTP em vez do esquema HTTPS. Se você continuar, sua comunicação não será criptografada."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O URL fornecido por você usa o HTTP em vez do esquema HTTPS. Se você continuar, sua comunicação não será criptografada."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The URL you provided uses the HTTP rather than the HTTPS scheme. If you continue, your communication will not be encrypted."
           }
         },
         "ru": {
@@ -28356,12 +20190,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "URL ที่คุณระบุใช้โปรโตคอล HTTP หากคุณดำเนินการต่อการสื่อสารของคุณจะไม่ถูกเข้ารหัส (แนะนำให้ใช้ HTTPS แทน)"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "URL ที่คุณระบุใช้โปรโตคอล HTTP หากคุณดำเนินการต่อการสื่อสารของคุณจะไม่ถูกเข้ารหัส (แนะนำให้ใช้ HTTPS แทน)"
@@ -28409,12 +20237,6 @@
             "value": "The action couldn't be performed on the targeted item because the client lacks permissions."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The action couldn't be performed on the targeted item because the client lacks permissions."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -28439,34 +20261,10 @@
             "value": "The action couldn't be performed on the targeted item because the client lacks permissions."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The action couldn't be performed on the targeted item because the client lacks permissions."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The action couldn't be performed on the targeted item because the client lacks permissions."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "A ação não pôde ser executada no item de destino porque o cliente não tem permissões."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A ação não pôde ser executada no item de destino porque o cliente não tem permissões."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The action couldn't be performed on the targeted item because the client lacks permissions."
           }
         },
         "ru": {
@@ -28482,12 +20280,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไคลเอนต์ไม่มีสิทธิ์ดำเนินการกับรายการเป้าหมาย"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไคลเอนต์ไม่มีสิทธิ์ดำเนินการกับรายการเป้าหมาย"
@@ -28529,12 +20321,6 @@
             "value": "The action couldn't be performed on the targeted item because the client lacks permisssions."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The action couldn't be performed on the targeted item because the client lacks permisssions."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -28565,31 +20351,7 @@
             "value": "The action couldn't be performed on the targeted item because the client lacks permisssions."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The action couldn't be performed on the targeted item because the client lacks permisssions."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The action couldn't be performed on the targeted item because the client lacks permisssions."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The action couldn't be performed on the targeted item because the client lacks permisssions."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The action couldn't be performed on the targeted item because the client lacks permisssions."
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "The action couldn't be performed on the targeted item because the client lacks permisssions."
@@ -28602,12 +20364,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The action couldn't be performed on the targeted item because the client lacks permisssions."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "The action couldn't be performed on the targeted item because the client lacks permisssions."
@@ -28647,12 +20403,6 @@
             "value": "The certificate for %@ has previously been rejected by the user."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The certificate for %@ has previously been rejected by the user."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -28677,30 +20427,6 @@
             "value": "The certificate for %@ has previously been rejected by the user."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The certificate for %@ has previously been rejected by the user."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The certificate for %@ has previously been rejected by the user."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The certificate for %@ has previously been rejected by the user."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The certificate for %@ has previously been rejected by the user."
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -28708,12 +20434,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The certificate for %@ has previously been rejected by the user."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "The certificate for %@ has previously been rejected by the user."
@@ -28753,12 +20473,6 @@
             "value": "The certificate for %1$@ passes TLS validation but doesn't pass the acceptance rule to replace the certificate for %2$@."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The certificate for %1$@ passes TLS validation but doesn't pass the acceptance rule to replace the certificate for %2$@."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -28783,30 +20497,6 @@
             "value": "The certificate for %1$@ passes TLS validation but doesn't pass the acceptance rule to replace the certificate for %2$@."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The certificate for %1$@ passes TLS validation but doesn't pass the acceptance rule to replace the certificate for %2$@."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The certificate for %1$@ passes TLS validation but doesn't pass the acceptance rule to replace the certificate for %2$@."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The certificate for %1$@ passes TLS validation but doesn't pass the acceptance rule to replace the certificate for %2$@."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The certificate for %1$@ passes TLS validation but doesn't pass the acceptance rule to replace the certificate for %2$@."
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -28814,12 +20504,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The certificate for %1$@ passes TLS validation but doesn't pass the acceptance rule to replace the certificate for %2$@."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "The certificate for %1$@ passes TLS validation but doesn't pass the acceptance rule to replace the certificate for %2$@."
@@ -28867,12 +20551,6 @@
             "value": "The certificate is invalid or contains errors"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The certificate is invalid or contains errors"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -28903,19 +20581,7 @@
             "value": "The certificate is invalid or contains errors"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The certificate is invalid or contains errors"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The certificate is invalid or contains errors"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "The certificate is invalid or contains errors"
@@ -28925,18 +20591,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "O certificado é inválido ou contém erros"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O certificado é inválido ou contém erros"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The certificate is invalid or contains errors"
           }
         },
         "ru": {
@@ -28952,12 +20606,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ใบรับรองไม่ถูกต้องหรือมีข้อผิดพลาด"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ใบรับรองไม่ถูกต้องหรือมีข้อผิดพลาด"
@@ -28997,12 +20645,6 @@
             "value": "The connection is redirected from %1$@ to %2$@."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The connection is redirected from %1$@ to %2$@."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -29027,30 +20669,6 @@
             "value": "The connection is redirected from %1$@ to %2$@."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The connection is redirected from %1$@ to %2$@."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The connection is redirected from %1$@ to %2$@."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The connection is redirected from %1$@ to %2$@."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The connection is redirected from %1$@ to %2$@."
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -29058,12 +20676,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The connection is redirected from %1$@ to %2$@."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "The connection is redirected from %1$@ to %2$@."
@@ -29109,12 +20721,6 @@
             "value": "The contents of the file on the server has changed since initiating download - or the file is no longer available on the server."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The contents of the file on the server has changed since initiating download - or the file is no longer available on the server."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -29139,34 +20745,10 @@
             "value": "The contents of the file on the server has changed since initiating download - or the file is no longer available on the server."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The contents of the file on the server has changed since initiating download - or the file is no longer available on the server."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The contents of the file on the server has changed since initiating download - or the file is no longer available on the server."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "O conteúdo do arquivo no servidor mudou desde o início da tarefa de baixar o arquivo - ou o arquivo não está mais disponível no servidor. "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O conteúdo do arquivo no servidor mudou desde o início da tarefa de baixar o arquivo - ou o arquivo não está mais disponível no servidor. "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The contents of the file on the server has changed since initiating download - or the file is no longer available on the server."
           }
         },
         "ru": {
@@ -29182,12 +20764,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เนื้อหาของไฟล์บนเซิร์ฟเวอร์มีการเปลี่ยนแปลงตั้งแต่เริ่มดาวน์โหลด - หรือไฟล์ไม่พร้อมใช้งานบนเซิร์ฟเวอร์อีกต่อไป"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "เนื้อหาของไฟล์บนเซิร์ฟเวอร์มีการเปลี่ยนแปลงตั้งแต่เริ่มดาวน์โหลด - หรือไฟล์ไม่พร้อมใช้งานบนเซิร์ฟเวอร์อีกต่อไป"
@@ -29229,12 +20805,6 @@
             "value": "The destination item has not been found."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The destination item has not been found."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -29265,31 +20835,7 @@
             "value": "The destination item has not been found."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The destination item has not been found."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The destination item has not been found."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The destination item has not been found."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The destination item has not been found."
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "The destination item has not been found."
@@ -29302,12 +20848,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The destination item has not been found."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "The destination item has not been found."
@@ -29353,12 +20893,6 @@
             "value": "The downloaded file's checksum does not match the checksum provided by the server."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The downloaded file's checksum does not match the checksum provided by the server."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -29383,34 +20917,10 @@
             "value": "The downloaded file's checksum does not match the checksum provided by the server."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The downloaded file's checksum does not match the checksum provided by the server."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The downloaded file's checksum does not match the checksum provided by the server."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "A soma de verificação do arquivo baixado não corresponde à soma de verificação fornecida pelo servidor. "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A soma de verificação do arquivo baixado não corresponde à soma de verificação fornecida pelo servidor. "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The downloaded file's checksum does not match the checksum provided by the server."
           }
         },
         "ru": {
@@ -29426,12 +20936,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่พบทรัพยากร"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไม่พบทรัพยากร"
@@ -29471,12 +20975,6 @@
             "value": "The file no longer exists on the server in this location."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The file no longer exists on the server in this location."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -29501,30 +20999,6 @@
             "value": "The file no longer exists on the server in this location."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The file no longer exists on the server in this location."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The file no longer exists on the server in this location."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The file no longer exists on the server in this location."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The file no longer exists on the server in this location."
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -29532,12 +21006,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The file no longer exists on the server in this location."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "The file no longer exists on the server in this location."
@@ -29585,12 +21053,6 @@
             "value": "The logged in user is not matching the required user ID."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The logged in user is not matching the required user ID."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -29615,34 +21077,10 @@
             "value": "The logged in user is not matching the required user ID."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The logged in user is not matching the required user ID."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The logged in user is not matching the required user ID."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "O usuário conectado não corresponde ao ID de usuário necessário. "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O usuário conectado não corresponde ao ID de usuário necessário. "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The logged in user is not matching the required user ID."
           }
         },
         "ru": {
@@ -29658,12 +21096,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ผู้ใช้ที่ล็อกอินไม่ตรงกับ ID ผู้ใช้ที่ต้องการ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ผู้ใช้ที่ล็อกอินไม่ตรงกับ ID ผู้ใช้ที่ต้องการ"
@@ -29711,12 +21143,6 @@
             "value": "The operation on the targeted item is not allowed."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The operation on the targeted item is not allowed."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -29747,19 +21173,7 @@
             "value": "The operation on the targeted item is not allowed."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The operation on the targeted item is not allowed."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The operation on the targeted item is not allowed."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "The operation on the targeted item is not allowed."
@@ -29769,18 +21183,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "A operação no item de destino não é permitida."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A operação no item de destino não é permitida."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The operation on the targeted item is not allowed."
           }
         },
         "ru": {
@@ -29796,12 +21198,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่อนุญาตให้ดำเนินการกับรายการเป้าหมาย"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไม่อนุญาตให้ดำเนินการกับรายการเป้าหมาย"
@@ -29849,12 +21245,6 @@
             "value": "The operation was cancelled."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The operation was cancelled."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -29885,19 +21275,7 @@
             "value": "The operation was cancelled."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The operation was cancelled."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The operation was cancelled."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "The operation was cancelled."
@@ -29907,18 +21285,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "A operação foi cancelada."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A operação foi cancelada."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The operation was cancelled."
           }
         },
         "ru": {
@@ -29934,12 +21300,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การดำเนินการถูกยกเลิก"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "การดำเนินการถูกยกเลิก"
@@ -29987,12 +21347,6 @@
             "value": "The provided path is not normalised."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The provided path is not normalised."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -30017,34 +21371,10 @@
             "value": "The provided path is not normalized."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The provided path is not normalized."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The provided path is not normalized."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "O caminho fornecido não está normalizado. "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O caminho fornecido não está normalizado. "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The provided path is not normalized."
           }
         },
         "ru": {
@@ -30060,12 +21390,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Path ที่ระบุไม่ได้ทำให้เป็นค่าปกติ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Path ที่ระบุไม่ได้ทำให้เป็นค่าปกติ"
@@ -30111,12 +21435,6 @@
             "value": "The target directory %@ doesn't seem to exist."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The target directory %@ doesn't seem to exist."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -30147,19 +21465,7 @@
             "value": "The target directory %@ doesn't seem to exist."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The target directory %@ doesn't seem to exist."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The target directory %@ doesn't seem to exist."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "The target directory %@ doesn't seem to exist."
@@ -30169,18 +21475,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "O diretório de destino %@ parece não existir."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O diretório de destino %@ parece não existir."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The target directory %@ doesn't seem to exist."
           }
         },
         "ru": {
@@ -30196,12 +21490,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่พบไดเร็กทอรี %@"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไม่พบไดเร็กทอรี %@"
@@ -30249,12 +21537,6 @@
             "value": "The target location has not been found."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The target location has not been found."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -30279,34 +21561,10 @@
             "value": "The target location has not been found."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The target location has not been found."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The target location has not been found."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "O local de destino não foi encontrado."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O local de destino não foi encontrado."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The target location has not been found."
           }
         },
         "ru": {
@@ -30322,12 +21580,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The target location has not been found."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "The target location has not been found."
@@ -30375,12 +21627,6 @@
             "value": "The targeted item has changed."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The targeted item has changed."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -30411,19 +21657,7 @@
             "value": "The targeted item has changed."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The targeted item has changed."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The targeted item has changed."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "The targeted item has changed."
@@ -30433,18 +21667,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "O item referenciadoado foi alterado."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O item referenciadoado foi alterado."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The targeted item has changed."
           }
         },
         "ru": {
@@ -30460,12 +21682,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "รายการเป้าหมายมีการเปลี่ยนแปลง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "รายการเป้าหมายมีการเปลี่ยนแปลง"
@@ -30513,12 +21729,6 @@
             "value": "The targeted item has not been found."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The targeted item has not been found."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -30549,19 +21759,7 @@
             "value": "The targeted item has not been found."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The targeted item has not been found."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The targeted item has not been found."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "The targeted item has not been found."
@@ -30571,18 +21769,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "O item de destino não foi encontrado."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O item de destino não foi encontrado."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The targeted item has not been found."
           }
         },
         "ru": {
@@ -30598,12 +21784,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่พบรายการเป้าหมาย"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไม่พบรายการเป้าหมาย"
@@ -30651,12 +21831,6 @@
             "value": "There already is an item at the destination of this action."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "There already is an item at the destination of this action."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -30687,19 +21861,7 @@
             "value": "There already is an item at the destination of this action."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "There already is an item at the destination of this action."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "There already is an item at the destination of this action."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "There already is an item at the destination of this action."
@@ -30709,18 +21871,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Já existe um item no destino desta ação."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Já existe um item no destino desta ação."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "There already is an item at the destination of this action."
           }
         },
         "ru": {
@@ -30736,12 +21886,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "มีการกระทำรายการนี้อยู่ที่ปลายทางแล้ว"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "มีการกระทำรายการนี้อยู่ที่ปลายทางแล้ว"
@@ -30789,12 +21933,6 @@
             "value": "This feature is currently not implemented"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This feature is currently not implemented"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -30825,19 +21963,7 @@
             "value": "This feature is currently not implemented"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This feature is currently not implemented"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This feature is currently not implemented"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "This feature is currently not implemented"
@@ -30847,18 +21973,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Este recurso não está atualmente implementado"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Este recurso não está atualmente implementado"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This feature is currently not implemented"
           }
         },
         "ru": {
@@ -30874,12 +21988,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ยังไม่เปิดใช้งานคุณลักษณะนี้ในปัจจุบัน"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ยังไม่เปิดใช้งานคุณลักษณะนี้ในปัจจุบัน"
@@ -30927,12 +22035,6 @@
             "value": "This feature is not supported for this item."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This feature is not supported for this item."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -30963,19 +22065,7 @@
             "value": "This feature is not supported for this item."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This feature is not supported for this item."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This feature is not supported for this item."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "This feature is not supported for this item."
@@ -30985,18 +22075,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Este recurso não é suportado para este item."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Este recurso não é suportado para este item."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This feature is not supported for this item."
           }
         },
         "ru": {
@@ -31012,12 +22090,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "คุณสมบัตินี้ไม่รองรับสำหรับรายการนี้"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "คุณสมบัตินี้ไม่รองรับสำหรับรายการนี้"
@@ -31065,12 +22137,6 @@
             "value": "This feature is not supported for this server (version)."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This feature is not supported for this server (version)."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -31101,19 +22167,7 @@
             "value": "This feature is not supported for this server (version)."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This feature is not supported for this server (version)."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This feature is not supported for this server (version)."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "This feature is not supported for this server (version)."
@@ -31123,18 +22177,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Este recurso não é suportado para este (versão) servidor."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Este recurso não é suportado para este (versão) servidor."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This feature is not supported for this server (version)."
           }
         },
         "ru": {
@@ -31150,12 +22192,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เซิร์ฟเวอร์ยังไม่รองรับคุณสมบัตินี้"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "เซิร์ฟเวอร์ยังไม่รองรับคุณสมบัตินี้"
@@ -31202,12 +22238,6 @@
             "value": "This file is currently being processed and is not yet available for use. Please try again shortly."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This file is currently being processed and is not yet available for use. Please try again shortly."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -31232,34 +22262,10 @@
             "value": "This file is currently being processed and is not yet available for use. Please try again shortly."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This file is currently being processed and is not yet available for use. Please try again shortly."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This file is currently being processed and is not yet available for use. Please try again shortly."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Este arquivo está sendo processado e ainda não está disponível para uso. Tente novamente em breve."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Este arquivo está sendo processado e ainda não está disponível para uso. Tente novamente em breve."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This file is currently being processed and is not yet available for use. Please try again shortly."
           }
         },
         "ru": {
@@ -31275,12 +22281,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This file is currently being processed and is not yet available for use. Please try again shortly."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "This file is currently being processed and is not yet available for use. Please try again shortly."
@@ -31326,12 +22326,6 @@
             "value": "This server runs an unsupported version (%@). Version %@ or later is required by this app."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This server runs an unsupported version (%@). Version %@ or later is required by this app."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -31362,19 +22356,7 @@
             "value": "This server runs an unsupported version (%@). Version %@ or later is required by this app."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This server runs an unsupported version (%@). Version %@ or later is required by this app."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This server runs an unsupported version (%@). Version %@ or later is required by this app."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "This server runs an unsupported version (%@). Version %@ or later is required by this app."
@@ -31384,18 +22366,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Este servidor roda uma versão não suportada ( %@ ). Versão %@ ou superior, é requerida para rodar este aplicativo."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Este servidor roda uma versão não suportada ( %@ ). Versão %@ ou superior, é requerida para rodar este aplicativo."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This server runs an unsupported version (%@). Version %@ or later is required by this app."
           }
         },
         "ru": {
@@ -31411,12 +22381,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เซิร์ฟเวอร์นี้กำลังใช้เวอร์ชันที่ไม่ได้รับการสนับสนุน (%@) เวอร์ชัน %@ หรือเก่ากว่าที่แอปนี้ต้องการ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "เซิร์ฟเวอร์นี้กำลังใช้เวอร์ชันที่ไม่ได้รับการสนับสนุน (%@) เวอร์ชัน %@ หรือเก่ากว่าที่แอปนี้ต้องการ"
@@ -31464,12 +22428,6 @@
             "value": "This server version is not supported."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This server version is not supported."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -31500,19 +22458,7 @@
             "value": "This server version is not supported."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This server version is not supported."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This server version is not supported."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "This server version is not supported."
@@ -31522,18 +22468,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Esta versão do servidor não é suportada."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esta versão do servidor não é suportada."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This server version is not supported."
           }
         },
         "ru": {
@@ -31549,12 +22483,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ยังไม่รองรับเซิร์ฟเวอร์เวอร์ชันนี้"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ยังไม่รองรับเซิร์ฟเวอร์เวอร์ชันนี้"
@@ -31600,12 +22528,6 @@
             "value": "Thumbnail database size"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Thumbnail database size"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -31630,34 +22552,10 @@
             "value": "Thumbnail database size"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Thumbnail database size"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Thumbnail database size"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Tamanho do banco de dados de miniaturas "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tamanho do banco de dados de miniaturas "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Thumbnail database size"
           }
         },
         "ru": {
@@ -31673,12 +22571,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ขนาดฐานข้อมูลภาพขนาดย่อ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ขนาดฐานข้อมูลภาพขนาดย่อ"
@@ -31724,12 +22616,6 @@
             "value": "Timestamp"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Timestamp"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -31754,34 +22640,10 @@
             "value": "Timestamp"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Timestamp"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Timestamp"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Carimbo de tempo "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Carimbo de tempo "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Timestamp"
           }
         },
         "ru": {
@@ -31797,12 +22659,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ประทับเวลา"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ประทับเวลา"
@@ -31844,12 +22700,6 @@
             "value": "Too few {{localizedName}}"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Too few {{localizedName}}"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -31874,30 +22724,6 @@
             "value": "Too few {{localizedName}}"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Too few {{localizedName}}"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Too few {{localizedName}}"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Too few {{localizedName}}"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Too few {{localizedName}}"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -31905,12 +22731,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Too few {{localizedName}}"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Too few {{localizedName}}"
@@ -31952,12 +22772,6 @@
             "value": "Too many {{localizedName}}"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Too many {{localizedName}}"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -31982,30 +22796,6 @@
             "value": "Too many {{localizedName}}"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Too many {{localizedName}}"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Too many {{localizedName}}"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Too many {{localizedName}}"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Too many {{localizedName}}"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -32013,12 +22803,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Too many {{localizedName}}"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Too many {{localizedName}}"
@@ -32064,12 +22848,6 @@
             "value": "Total Items"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Total Items"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -32094,34 +22872,10 @@
             "value": "Total Items"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Total Items"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Total Items"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Total de Itens"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Total de Itens"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Total Items"
           }
         },
         "ru": {
@@ -32137,12 +22891,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "รายการทั้งหมด"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "รายการทั้งหมด"
@@ -32188,12 +22936,6 @@
             "value": "URL"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "URL"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -32218,31 +22960,7 @@
             "value": "URL"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "URL"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "URL"
-          }
-        },
         "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "URL"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "URL"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "URL"
@@ -32261,12 +22979,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "URL"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "URL"
@@ -32312,12 +23024,6 @@
             "value": "UUID"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "UUID"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -32342,31 +23048,7 @@
             "value": "UUID"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "UUID"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "UUID"
-          }
-        },
         "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "UUID"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "UUID"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "UUID"
@@ -32385,12 +23067,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "UUID"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "UUID"
@@ -32438,12 +23114,6 @@
             "value": "Unknown share type."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unknown share type."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -32468,34 +23138,10 @@
             "value": "Unknown share type."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unknown share type."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unknown share type."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Tipo de compartilhamento desconhecido."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tipo de compartilhamento desconhecido."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unknown share type."
           }
         },
         "ru": {
@@ -32511,12 +23157,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ประเภทการแชร์ที่ไม่รู้จัก"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ประเภทการแชร์ที่ไม่รู้จัก"
@@ -32564,12 +23204,6 @@
             "value": "Unknown user"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unknown user"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -32594,34 +23228,10 @@
             "value": "Unknown user"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unknown user"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unknown user"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Usuário desconhecido"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usuário desconhecido"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unknown user"
           }
         },
         "ru": {
@@ -32637,12 +23247,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่รู้จักผู้ใช้"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไม่รู้จักผู้ใช้"
@@ -32682,12 +23286,6 @@
             "value": "Update failed with status code %lu"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Update failed with status code %lu"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -32712,30 +23310,6 @@
             "value": "Update failed with status code %lu"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Update failed with status code %lu"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Update failed with status code %lu"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Update failed with status code %lu"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Update failed with status code %lu"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -32743,12 +23317,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Update failed with status code %lu"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Update failed with status code %lu"
@@ -32788,12 +23356,6 @@
             "value": "Updating metadata for '%@'…"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Updating metadata for '%@'…"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -32818,30 +23380,6 @@
             "value": "Updating metadata for '%@'…"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Updating metadata for '%@'…"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Updating metadata for '%@'…"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Updating metadata for '%@'…"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Updating metadata for '%@'…"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -32849,12 +23387,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Updating metadata for '%@'…"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Updating metadata for '%@'…"
@@ -32894,12 +23426,6 @@
             "value": "Updating share…"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Updating share…"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -32924,30 +23450,6 @@
             "value": "Updating share…"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Updating share…"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Updating share…"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Updating share…"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Updating share…"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -32955,12 +23457,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Updating share…"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Updating share…"
@@ -33007,12 +23503,6 @@
             "value": "Upgrading database…"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Upgrading database…"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -33037,34 +23527,10 @@
             "value": "Upgrading database…"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Upgrading database…"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Upgrading database…"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Atualizando banco de dados... "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Atualizando banco de dados... "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Upgrading database…"
           }
         },
         "ru": {
@@ -33080,12 +23546,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กำลังอัปเกรดฐานข้อมูล..."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "กำลังอัปเกรดฐานข้อมูล..."
@@ -33131,12 +23591,6 @@
             "value": "Upload, edit, delete, download and preview"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Upload, edit, delete, download and preview"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -33161,34 +23615,10 @@
             "value": "Upload, edit, delete, download and preview"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Upload, edit, delete, download and preview"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Upload, edit, delete, download and preview"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Carregar, editar, excluir, baixar e visualizar"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Carregar, editar, excluir, baixar e visualizar"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Upload, edit, delete, download and preview"
           }
         },
         "ru": {
@@ -33204,12 +23634,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Upload, edit, delete, download and preview"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Upload, edit, delete, download and preview"
@@ -33255,12 +23679,6 @@
             "value": "Upload, edit, delete, download, preview and share"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Upload, edit, delete, download, preview and share"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -33285,34 +23703,10 @@
             "value": "Upload, edit, delete, download, preview and share"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Upload, edit, delete, download, preview and share"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Upload, edit, delete, download, preview and share"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Carregar, editar, excluir, baixar, visualizar e compartilhar"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Carregar, editar, excluir, baixar, visualizar e compartilhar"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Upload, edit, delete, download, preview and share"
           }
         },
         "ru": {
@@ -33328,12 +23722,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Upload, edit, delete, download, preview and share"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Upload, edit, delete, download, preview and share"
@@ -33379,12 +23767,6 @@
             "value": "Uploader"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uploader"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -33409,34 +23791,10 @@
             "value": "Uploader"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uploader"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uploader"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Enviador"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enviador"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uploader"
           }
         },
         "ru": {
@@ -33452,12 +23810,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uploader"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Uploader"
@@ -33497,12 +23849,6 @@
             "value": "Uploading %@…"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uploading %@…"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -33527,30 +23873,6 @@
             "value": "Uploading %@…"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uploading %@…"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uploading %@…"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uploading %@…"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uploading %@…"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -33558,12 +23880,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uploading %@…"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Uploading %@…"
@@ -33609,12 +23925,6 @@
             "value": "Uploads to this folder are not allowed."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uploads to this folder are not allowed."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -33639,34 +23949,10 @@
             "value": "Uploads to this folder are not allowed."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uploads to this folder are not allowed."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uploads to this folder are not allowed."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "O envio para esta pasta não é permitido. "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O envio para esta pasta não é permitido. "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uploads to this folder are not allowed."
           }
         },
         "ru": {
@@ -33682,12 +23968,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่อนุญาตให้อัปโหลดไปยังโฟลเดอร์นี้"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไม่อนุญาตให้อัปโหลดไปยังโฟลเดอร์นี้"
@@ -33733,12 +24013,6 @@
             "value": "Use Origin URL as URL"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use Origin URL as URL"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -33763,34 +24037,10 @@
             "value": "Use Origin URL as URL"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use Origin URL as URL"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use Origin URL as URL"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Use a Original URL como URL "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use a Original URL como URL "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use Origin URL as URL"
           }
         },
         "ru": {
@@ -33806,12 +24056,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ใช้ URL ต้นทางเป็น URL"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ใช้ URL ต้นทางเป็น URL"
@@ -33857,12 +24101,6 @@
             "value": "User Name"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "User Name"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -33887,34 +24125,10 @@
             "value": "User Name"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "User Name"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "User Name"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Nome do Usuário "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nome do Usuário "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "User Name"
           }
         },
         "ru": {
@@ -33930,12 +24144,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ชื่อผู้ใช้"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ชื่อผู้ใช้"
@@ -33981,12 +24189,6 @@
             "value": "UserInfo"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "UserInfo"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -34011,34 +24213,10 @@
             "value": "UserInfo"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "UserInfo"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "UserInfo"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Informação do Usuário "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Informação do Usuário "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "UserInfo"
           }
         },
         "ru": {
@@ -34054,12 +24232,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ข้อมูลผู้ใช้"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ข้อมูลผู้ใช้"
@@ -34105,12 +24277,6 @@
             "value": "Vacuum"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vacuum"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -34135,34 +24301,10 @@
             "value": "Vacuum"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vacuum"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vacuum"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Vácuo "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vácuo "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vacuum"
           }
         },
         "ru": {
@@ -34178,12 +24320,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เครื่องดูดฝุ่น"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "เครื่องดูดฝุ่น"
@@ -34229,12 +24365,6 @@
             "value": "Viewer"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Viewer"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -34259,34 +24389,10 @@
             "value": "Viewer"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Viewer"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Viewer"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Visualizador"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Visualizador"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Viewer"
           }
         },
         "ru": {
@@ -34302,12 +24408,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Viewer"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Viewer"
@@ -34353,12 +24453,6 @@
             "value": "Wait Conditions"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wait Conditions"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -34383,34 +24477,10 @@
             "value": "Wait Conditions"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wait Conditions"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wait Conditions"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Condições de Espera "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Condições de Espera "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wait Conditions"
           }
         },
         "ru": {
@@ -34426,12 +24496,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เงื่อนไขการรอ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "เงื่อนไขการรอ"
@@ -34477,12 +24541,6 @@
             "value": "Waiting for metadata refresh"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Waiting for metadata refresh"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -34507,34 +24565,10 @@
             "value": "Waiting for metadata refresh"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Waiting for metadata refresh"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Waiting for metadata refresh"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Aguardando atualização de metadados "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aguardando atualização de metadados "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Waiting for metadata refresh"
           }
         },
         "ru": {
@@ -34550,12 +24584,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กำลังรอการรีเฟรชข้อมูล metadata"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "กำลังรอการรีเฟรชข้อมูล metadata"
@@ -34601,12 +24629,6 @@
             "value": "Waiting for user"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Waiting for user"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -34631,34 +24653,10 @@
             "value": "Waiting for user"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Waiting for user"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Waiting for user"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Esperando pelo usuário "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esperando pelo usuário "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Waiting for user"
           }
         },
         "ru": {
@@ -34674,12 +24672,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กำลังรอผู้ใช้"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "กำลังรอผู้ใช้"
@@ -34725,12 +24717,6 @@
             "value": "Waiting to retry (%ld of %ld)"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Waiting to retry (%ld of %ld)"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -34755,34 +24741,10 @@
             "value": "Waiting to retry (%ld of %ld)"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Waiting to retry (%ld of %ld)"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Waiting to retry (%ld of %ld)"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Esperando para tentar novamente  (%ld de %ld)"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esperando para tentar novamente  (%ld de %ld)"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Waiting to retry (%ld of %ld)"
           }
         },
         "ru": {
@@ -34798,12 +24760,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กำลังรอเพื่อลองใหม่ (%ld จาก %ld)"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "กำลังรอเพื่อลองใหม่ (%ld จาก %ld)"
@@ -34851,12 +24807,6 @@
             "value": "Web finger response lacks server instance relation."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Web finger response lacks server instance relation."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -34881,34 +24831,10 @@
             "value": "Web finger response lacks server instance relation."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Web finger response lacks server instance relation."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Web finger response lacks server instance relation."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "A resposta do dedo da Web carece de relação de instância do servidor."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A resposta do dedo da Web carece de relação de instância do servidor."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Web finger response lacks server instance relation."
           }
         },
         "ru": {
@@ -34924,12 +24850,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Web finger response lacks server instance relation."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Web finger response lacks server instance relation."
@@ -34975,12 +24895,6 @@
             "value": "You logged in as user %@, but must log in as user %@. Please retry."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You logged in as user %@, but must log in as user %@. Please retry."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -35005,34 +24919,10 @@
             "value": "You logged in as user %@, but must log in as user %@. Please retry."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You logged in as user %@, but must log in as user %@. Please retry."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You logged in as user %@, but must log in as user %@. Please retry."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "Você efetuou login como usuário %@, mas deve efetuar login como usuário %@. Por favor tente novamente. "
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Você efetuou login como usuário %@, mas deve efetuar login como usuário %@. Por favor tente novamente. "
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You logged in as user %@, but must log in as user %@. Please retry."
           }
         },
         "ru": {
@@ -35048,12 +24938,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "คุณเข้าสู่ระบบในฐานะผู้ใช้ %@ แต่จำเป็นต้องเข้าสู่ระบบในฐานะผู้ใช้ %@ โปรดลองอีกครั้ง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "คุณเข้าสู่ระบบในฐานะผู้ใช้ %@ แต่จำเป็นต้องเข้าสู่ระบบในฐานะผู้ใช้ %@ โปรดลองอีกครั้ง"
@@ -35094,12 +24978,6 @@
             "value": "characters"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "characters"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -35124,30 +25002,6 @@
             "value": "characters"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "characters"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "characters"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "characters"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "characters"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -35155,12 +25009,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "characters"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "characters"
@@ -35207,12 +25055,6 @@
             "value": "copy"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "copy"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -35237,34 +25079,10 @@
             "value": "copy"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "copy"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "copy"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "copiar"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "copiar"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "copy"
           }
         },
         "ru": {
@@ -35280,12 +25098,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "คัดลอก"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "คัดลอก"
@@ -35325,12 +25137,6 @@
             "value": "digits"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "digits"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -35355,30 +25161,6 @@
             "value": "digits"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "digits"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "digits"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "digits"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "digits"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -35386,12 +25168,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "digits"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "digits"
@@ -35439,12 +25215,6 @@
             "value": "Favourite"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Favourite"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -35475,19 +25245,7 @@
             "value": "Favorite"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Favorite"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Favorite"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Favorite"
@@ -35497,18 +25255,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Favorito"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Favorito"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Favorite"
           }
         },
         "ru": {
@@ -35524,12 +25270,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "รายการโปรด"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "รายการโปรด"
@@ -35577,12 +25317,6 @@
             "value": "Last modified"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Last modified"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -35613,19 +25347,7 @@
             "value": "Last modified"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Last modified"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Last modified"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Last modified"
@@ -35635,18 +25357,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Última modificação"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Última modificação"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Last modified"
           }
         },
         "ru": {
@@ -35662,12 +25372,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "แก้ไขครั้งล่าสุด"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "แก้ไขครั้งล่าสุด"
@@ -35715,12 +25419,6 @@
             "value": "Local attributes"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Local attributes"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -35751,19 +25449,7 @@
             "value": "Local attributes"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Local attributes"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Local attributes"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Local attributes"
@@ -35773,18 +25459,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Atributos locais"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Atributos locais"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Local attributes"
           }
         },
         "ru": {
@@ -35800,12 +25474,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "แอตทริบิวต์ต้นทาง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "แอตทริบิวต์ต้นทาง"
@@ -35845,12 +25513,6 @@
             "value": "lower-case characters"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "lower-case characters"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -35875,30 +25537,6 @@
             "value": "lower-case characters"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "lower-case characters"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "lower-case characters"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "lower-case characters"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "lower-case characters"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -35906,12 +25544,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "lower-case characters"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "lower-case characters"
@@ -35952,12 +25584,6 @@
             "value": "special characters"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "special characters"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -35982,30 +25608,6 @@
             "value": "special characters"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "special characters"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "special characters"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "special characters"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "special characters"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -36013,12 +25615,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "special characters"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "special characters"
@@ -36059,12 +25655,6 @@
             "value": "upper-case characters"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "upper-case characters"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -36089,30 +25679,6 @@
             "value": "upper-case characters"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "upper-case characters"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "upper-case characters"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "upper-case characters"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "upper-case characters"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -36120,12 +25686,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "upper-case characters"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "upper-case characters"
@@ -36171,12 +25731,6 @@
             "value": "{{itemName}} can't be copied into itself."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "{{itemName}} can't be copied into itself."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -36201,34 +25755,10 @@
             "value": "{{itemName}} can't be copied into itself."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "{{itemName}} can't be copied into itself."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "{{itemName}} can't be copied into itself."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "{{itemName}} não pode ser copiado para si mesmo."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "{{itemName}} não pode ser copiado para si mesmo."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "{{itemName}} can't be copied into itself."
           }
         },
         "ru": {
@@ -36244,12 +25774,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "{{itemName}} can't be copied into itself."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "{{itemName}} can't be copied into itself."
@@ -36295,12 +25819,6 @@
             "value": "{{itemName}} can't be moved into itself."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "{{itemName}} can't be moved into itself."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -36325,34 +25843,10 @@
             "value": "{{itemName}} can't be moved into itself."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "{{itemName}} can't be moved into itself."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "{{itemName}} can't be moved into itself."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "{{itemName}} não pode ser movido para si mesmo."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "{{itemName}} não pode ser movido para si mesmo."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "{{itemName}} can't be moved into itself."
           }
         },
         "ru": {
@@ -36368,12 +25862,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "{{itemName}} can't be moved into itself."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "{{itemName}} can't be moved into itself."
@@ -36420,12 +25908,6 @@
             "value": "{{itemName}} is currently processed on the server and can't be downloaded until it finishes processing."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "{{itemName}} is currently processed on the server and can't be downloaded until it finishes processing."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -36450,34 +25932,10 @@
             "value": "{{itemName}} is currently processed on the server and can't be downloaded until it finishes processing."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "{{itemName}} is currently processed on the server and can't be downloaded until it finishes processing."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "{{itemName}} is currently processed on the server and can't be downloaded until it finishes processing."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
             "value": "{{itemName}} é atualmente processado no servidor e não pode ser baixado até que termine o processamento."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "{{itemName}} é atualmente processado no servidor e não pode ser baixado até que termine o processamento."
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "{{itemName}} is currently processed on the server and can't be downloaded until it finishes processing."
           }
         },
         "ru": {
@@ -36493,12 +25951,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "{{itemName}} is currently processed on the server and can't be downloaded until it finishes processing."
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "{{itemName}} is currently processed on the server and can't be downloaded until it finishes processing."

--- a/ownCloudUI/Resources/Localizable.xcstrings
+++ b/ownCloudUI/Resources/Localizable.xcstrings
@@ -27,12 +27,6 @@
             "value": "Auto-accepted."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auto-accepted."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -57,18 +51,6 @@
             "value": "Auto-accepted."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auto-accepted."
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auto-accepted."
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -76,18 +58,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auto-accepted."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aceito automaticamente. "
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Auto-accepted."
@@ -106,12 +76,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ยอมรับโดยอัตโนมัติ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ยอมรับโดยอัตโนมัติ"
@@ -151,12 +115,6 @@
             "value": "Certificate Details"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate Details"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -181,30 +139,6 @@
             "value": "Certificate Details"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate Details"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate Details"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate Details"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate Details"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -212,12 +146,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate Details"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Certificate Details"
@@ -257,12 +185,6 @@
             "value": "Certificate chain"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate chain"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -287,30 +209,6 @@
             "value": "Certificate chain"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate chain"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate chain"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate chain"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate chain"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -318,12 +216,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate chain"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Certificate chain"
@@ -369,12 +261,6 @@
             "value": "Certificate has issues."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate has issues."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -405,19 +291,7 @@
             "value": "Certificate has issues."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate has issues."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Certificate has issues."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Certificate has issues."
@@ -430,18 +304,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O certificado tem problemas."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O certificado tem problemas."
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "O certificado tem problemas."
@@ -460,12 +322,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ใบรับรองมีปัญหา"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ใบรับรองมีปัญหา"
@@ -511,12 +367,6 @@
             "value": "Extensions"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Extensions"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -547,19 +397,7 @@
             "value": "Extensions"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Extensions"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Extensions"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Extensions"
@@ -572,18 +410,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Extensões"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Extensões"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Extensões"
@@ -602,12 +428,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ส่วนขยาย"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ส่วนขยาย"
@@ -653,12 +473,6 @@
             "value": "Fingerprints"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fingerprints"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -689,19 +503,7 @@
             "value": "Fingerprints"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fingerprints"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fingerprints"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Fingerprints"
@@ -714,18 +516,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Assinaturas Digitais"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Impressões digitais"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Assinaturas Digitais"
@@ -744,12 +534,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ลายนิ้วมือ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ลายนิ้วมือ"
@@ -795,12 +579,6 @@
             "value": "Hide ±"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hide ±"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -825,18 +603,6 @@
             "value": "Hide ±"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hide ±"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hide ±"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -844,18 +610,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hide ±"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esconder ± "
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Hide ±"
@@ -874,12 +628,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ซ่อน ±"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ซ่อน ±"
@@ -925,12 +673,6 @@
             "value": "Hostname"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hostname"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -961,19 +703,7 @@
             "value": "Hostname"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hostname"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hostname"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Hostname"
@@ -986,18 +716,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nome do Anfitrião"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nome do Host"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Nome do Anfitrião"
@@ -1016,12 +734,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ชื่อโฮสต์"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ชื่อโฮสต์"
@@ -1061,12 +773,6 @@
             "value": "Intermediate Certificate"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intermediate Certificate"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -1091,30 +797,6 @@
             "value": "Intermediate Certificate"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intermediate Certificate"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intermediate Certificate"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intermediate Certificate"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intermediate Certificate"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -1122,12 +804,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intermediate Certificate"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Intermediate Certificate"
@@ -1173,12 +849,6 @@
             "value": "Issuer"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Issuer"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -1209,19 +879,7 @@
             "value": "Issuer"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Issuer"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Issuer"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Issuer"
@@ -1234,18 +892,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Emissor"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gerador"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Emissor"
@@ -1264,12 +910,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ผู้ออก"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ผู้ออก"
@@ -1315,12 +955,6 @@
             "value": "No issues found."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No issues found."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -1351,19 +985,7 @@
             "value": "No issues found."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No issues found."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No issues found."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "No issues found."
@@ -1376,18 +998,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Não foram encontrados problemas."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Não foram encontrados problemas."
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Não foram encontrados problemas."
@@ -1406,12 +1016,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่พบปัญหา"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ไม่พบปัญหา"
@@ -1457,12 +1061,6 @@
             "value": "Public Key"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Public Key"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -1493,19 +1091,7 @@
             "value": "Public Key"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Public Key"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Public Key"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Public Key"
@@ -1518,18 +1104,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chave Pública"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chave pública"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Chave Pública"
@@ -1548,12 +1122,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "คีย์สาธารณะ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "คีย์สาธารณะ"
@@ -1599,12 +1167,6 @@
             "value": "Reason"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reason"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -1629,18 +1191,6 @@
             "value": "Reason"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reason"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reason"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -1648,18 +1198,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reason"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Razão "
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Reason"
@@ -1678,12 +1216,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เหตุผล"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "เหตุผล"
@@ -1723,12 +1255,6 @@
             "value": "Root Certificate"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Root Certificate"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -1753,30 +1279,6 @@
             "value": "Root Certificate"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Root Certificate"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Root Certificate"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Root Certificate"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Root Certificate"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -1784,12 +1286,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Root Certificate"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Root Certificate"
@@ -1836,12 +1332,6 @@
             "value": "Show ±"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show ±"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -1866,18 +1356,6 @@
             "value": "Show ±"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show ±"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show ±"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -1885,18 +1363,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show ±"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mostrar ± "
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Show ±"
@@ -1915,12 +1381,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "แสดง ±"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "แสดง ±"
@@ -1967,12 +1427,6 @@
             "value": "Subject"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Subject"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -2003,19 +1457,7 @@
             "value": "Subject"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Subject"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Subject"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Subject"
@@ -2028,18 +1470,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Assunto"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Assunto"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Assunto"
@@ -2058,12 +1488,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "หัวเรื่อง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "หัวเรื่อง"
@@ -2109,12 +1533,6 @@
             "value": "User-accepted."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "User-accepted."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -2145,19 +1563,7 @@
             "value": "User-accepted."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "User-accepted."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "User-accepted."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "User-accepted."
@@ -2170,18 +1576,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Utilizador aceite."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usuário aceito."
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Utilizador aceite."
@@ -2200,12 +1594,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ผู้ใช้งานได้รับการยอมรับ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ผู้ใช้งานได้รับการยอมรับ"
@@ -2251,12 +1639,6 @@
             "value": "User-rejected."
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "User-rejected."
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -2287,19 +1669,7 @@
             "value": "User-rejected."
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "User-rejected."
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "User-rejected."
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "User-rejected."
@@ -2312,18 +1682,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Utilizador rejeitado."
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usuário rejeitado."
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Utilizador rejeitado."
@@ -2342,12 +1700,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ผู้ใช้ที่ถูกปฏิเสธ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ผู้ใช้ที่ถูกปฏิเสธ"
@@ -2387,12 +1739,6 @@
             "value": "Validating…"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Validating…"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -2417,30 +1763,6 @@
             "value": "Validating…"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Validating…"
-          }
-        },
-        "nn_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Validating…"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Validating…"
-          }
-        },
-        "pt_PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Validating…"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -2448,12 +1770,6 @@
           }
         },
         "sq": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Validating…"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "Validating…"
@@ -2499,12 +1815,6 @@
             "value": "Validation Error"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Validation Error"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -2535,19 +1845,7 @@
             "value": "Validation Error"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Validation Error"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Validation Error"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Validation Error"
@@ -2560,18 +1858,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erro de Validação"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erro de validação"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Erro de Validação"
@@ -2590,12 +1876,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ข้อผิดพลาดในการตรวจสอบ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ข้อผิดพลาดในการตรวจสอบ"
@@ -2641,12 +1921,6 @@
             "value": "Validation Status"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Validation Status"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -2677,19 +1951,7 @@
             "value": "Validation Status"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Validation Status"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Validation Status"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Validation Status"
@@ -2702,18 +1964,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estado da Validação"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Status de validação"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Estado da Validação"
@@ -2732,12 +1982,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สถานะการตรวจสอบ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "สถานะการตรวจสอบ"
@@ -2785,12 +2029,6 @@
             "value": "Business category"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Business category"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -2821,19 +2059,7 @@
             "value": "Business category"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Business category"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Business category"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Business category"
@@ -2846,18 +2072,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Categoria de negócio"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Categoria de negócio"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Categoria de negócio"
@@ -2876,12 +2090,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ประเภทธุรกิจ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ประเภทธุรกิจ"
@@ -2928,12 +2136,6 @@
             "value": "Common name"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Common name"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -2964,19 +2166,7 @@
             "value": "Common name"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Common name"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Common name"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Common name"
@@ -2989,18 +2179,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nome comum"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nome comum"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Nome comum"
@@ -3019,12 +2197,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ชื่อสามัญ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ชื่อสามัญ"
@@ -3071,12 +2243,6 @@
             "value": "Country"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Country"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -3107,19 +2273,7 @@
             "value": "Country"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Country"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Country"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Country"
@@ -3132,18 +2286,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "País"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "País"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "País"
@@ -3162,12 +2304,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ประเทศ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ประเทศ"
@@ -3214,12 +2350,6 @@
             "value": "Jurisdiction country"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jurisdiction country"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -3250,19 +2380,7 @@
             "value": "Jurisdiction country"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jurisdiction country"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jurisdiction country"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Jurisdiction country"
@@ -3275,18 +2393,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "País de jurisdição"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "País de Jurisdição"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "País de jurisdição"
@@ -3305,12 +2411,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สังกัดประเทศ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "สังกัดประเทศ"
@@ -3357,12 +2457,6 @@
             "value": "Jurisdiction locality"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jurisdiction locality"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -3393,19 +2487,7 @@
             "value": "Jurisdiction locality"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jurisdiction locality"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jurisdiction locality"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Jurisdiction locality"
@@ -3418,18 +2500,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Localidade de jurisdição"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Local de Jurisdição"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Localidade de jurisdição"
@@ -3448,12 +2518,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สังกัดท้องที่"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "สังกัดท้องที่"
@@ -3500,12 +2564,6 @@
             "value": "Jurisdiction state or province"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jurisdiction state or province"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -3536,19 +2594,7 @@
             "value": "Jurisdiction state or province"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jurisdiction state or province"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jurisdiction state or province"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Jurisdiction state or province"
@@ -3561,18 +2607,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Concelho ou distrito de jurisdição"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estado ou província de jurisdição"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Concelho ou distrito de jurisdição"
@@ -3591,12 +2625,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "จังหวัด"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "จังหวัด"
@@ -3643,12 +2671,6 @@
             "value": "Key bytes"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Key bytes"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -3679,19 +2701,7 @@
             "value": "Key bytes"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Key bytes"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Key bytes"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Key bytes"
@@ -3704,18 +2714,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bytes chave"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bytes da chave"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Bytes chave"
@@ -3734,12 +2732,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "คีย์ไบต์"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "คีย์ไบต์"
@@ -3786,12 +2778,6 @@
             "value": "Key exponent"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Key exponent"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -3822,19 +2808,7 @@
             "value": "Key exponent"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Key exponent"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Key exponent"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Key exponent"
@@ -3847,18 +2821,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Expoente chave"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Expoente da chave"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Expoente chave"
@@ -3877,12 +2839,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "คีย์สัญลักษณ์"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "คีย์สัญลักษณ์"
@@ -3929,12 +2885,6 @@
             "value": "Information"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Information"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -3965,19 +2915,7 @@
             "value": "Information"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Information"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Information"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Information"
@@ -3990,18 +2928,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Informação"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Informações"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Informação"
@@ -4020,12 +2946,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สารสนเทศ"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "สารสนเทศ"
@@ -4072,12 +2992,6 @@
             "value": "Key size (bits)"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Key size (bits)"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -4108,19 +3022,7 @@
             "value": "Key size (bits)"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Key size (bits)"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Key size (bits)"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Key size (bits)"
@@ -4133,18 +3035,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tamanho da chave (bits)"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tamanho da chave (bits)"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Tamanho da chave (bits)"
@@ -4163,12 +3053,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ขนาดคีย์ (บิต)"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ขนาดคีย์ (บิต)"
@@ -4215,12 +3099,6 @@
             "value": "Locality"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Locality"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -4251,19 +3129,7 @@
             "value": "Locality"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Locality"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Locality"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Locality"
@@ -4276,18 +3142,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Localização"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Localidade"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Localização"
@@ -4306,12 +3160,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ตำบล"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ตำบล"
@@ -4358,12 +3206,6 @@
             "value": "Organisation"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Organisation"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -4394,19 +3236,7 @@
             "value": "Organization"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Organization"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Organization"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Organization"
@@ -4419,18 +3249,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Organização"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Organização"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Organização"
@@ -4449,12 +3267,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "หน่วยงาน"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "หน่วยงาน"
@@ -4501,12 +3313,6 @@
             "value": "Organisation Unit"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Organisation Unit"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -4537,19 +3343,7 @@
             "value": "Organization Unit"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Organization Unit"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Organization Unit"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Organization Unit"
@@ -4562,18 +3356,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unidade de Organização"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unidade de Organização"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Unidade de Organização"
@@ -4592,12 +3374,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "หน่วยองค์กร"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "หน่วยองค์กร"
@@ -4644,12 +3420,6 @@
             "value": "Serial Number"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Serial Number"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -4680,19 +3450,7 @@
             "value": "Serial Number"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Serial Number"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Serial Number"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Serial Number"
@@ -4705,18 +3463,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Número de Série"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Número de série"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Número de Série"
@@ -4735,12 +3481,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "หมายเลขผลิตภัณฑ์"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "หมายเลขผลิตภัณฑ์"
@@ -4787,12 +3527,6 @@
             "value": "Signature Algorithm"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Signature Algorithm"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -4823,19 +3557,7 @@
             "value": "Signature Algorithm"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Signature Algorithm"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Signature Algorithm"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Signature Algorithm"
@@ -4848,18 +3570,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Algoritmo de Assinatura"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Algoritmo de Assinatura"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Algoritmo de Assinatura"
@@ -4878,12 +3588,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "อัลกอริธึมลายเซ็น"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "อัลกอริธึมลายเซ็น"
@@ -4930,12 +3634,6 @@
             "value": "State or province"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "State or province"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -4966,19 +3664,7 @@
             "value": "State or province"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "State or province"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "State or province"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "State or province"
@@ -4991,18 +3677,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Concelho ou distrito"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estado ou província"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Concelho ou distrito"
@@ -5021,12 +3695,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "รัฐหรือจังหวัด"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "รัฐหรือจังหวัด"
@@ -5073,12 +3741,6 @@
             "value": "Valid from"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Valid from"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -5109,19 +3771,7 @@
             "value": "Valid from"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Valid from"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Valid from"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Valid from"
@@ -5134,18 +3784,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Válido de"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Válido de"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Válido de"
@@ -5164,12 +3802,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ใช้ได้ตั้งแต่"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ใช้ได้ตั้งแต่"
@@ -5216,12 +3848,6 @@
             "value": "Valid until"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Valid until"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -5252,19 +3878,7 @@
             "value": "Valid until"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Valid until"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Valid until"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Valid until"
@@ -5277,18 +3891,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Válido até"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Válido até"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Válido até"
@@ -5307,12 +3909,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ใช้ได้จนถึง"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "ใช้ได้จนถึง"
@@ -5359,12 +3955,6 @@
             "value": "Version"
           }
         },
-        "en_GB": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Version"
-          }
-        },
         "es": {
           "stringUnit": {
             "state": "translated",
@@ -5395,19 +3985,7 @@
             "value": "Version"
           }
         },
-        "nb_NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Version"
-          }
-        },
         "nn-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Version"
-          }
-        },
-        "nn_NO": {
           "stringUnit": {
             "state": "translated",
             "value": "Version"
@@ -5420,18 +3998,6 @@
           }
         },
         "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versão"
-          }
-        },
-        "pt_BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versão"
-          }
-        },
-        "pt_PT": {
           "stringUnit": {
             "state": "translated",
             "value": "Versão"
@@ -5450,12 +4016,6 @@
           }
         },
         "th-TH": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เวอร์ชัน"
-          }
-        },
-        "th_TH": {
           "stringUnit": {
             "state": "translated",
             "value": "เวอร์ชัน"


### PR DESCRIPTION
## Description
 Removes duplicate locale keys before push and after pull from Transifex.

## Related Issue
https://community.transifex.com/t/xcstrings-again/4252/2?u=thomas.mueller

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)