### PR TITLE
[feature/security-first] Add capability control to allow password removal independent of password enforcement

### DIFF
--- a/ownCloudSDK/Connection/Capabilities/OCCapabilities.h
+++ b/ownCloudSDK/Connection/Capabilities/OCCapabilities.h
@@ -114,6 +114,11 @@ typedef NSNumber* OCCapabilityBool;
 @property(readonly,nullable,nonatomic) OCCapabilityBool publicSharingPasswordEnforcedForReadWrite; //!< Controls whether a password is required for read-write links
 @property(readonly,nullable,nonatomic) OCCapabilityBool publicSharingPasswordEnforcedForReadWriteDelete; //!< Controls whether a password is required for read-write-delete links
 @property(readonly,nullable,nonatomic) OCCapabilityBool publicSharingPasswordEnforcedForUploadOnly; //!< Controls whether a password is required for upload-only links
+@property(readonly,nullable,nonatomic) OCCapabilityBool publicSharingPasswordBlockRemovalForReadOnly; //!< Controls whether the removal of a password is blocked for read-only links
+@property(readonly,nullable,nonatomic) OCCapabilityBool publicSharingPasswordBlockRemovalForReadWrite; //!< Controls whether the removal of a password is blocked for read-write links
+@property(readonly,nullable,nonatomic) OCCapabilityBool publicSharingPasswordBlockRemovalForReadWriteDelete; //!< Controls whether the removal of a password is blocked for read-write-delete links
+@property(readonly,nullable,nonatomic) OCCapabilityBool publicSharingPasswordBlockRemovalForUploadOnly; //!< Controls whether the removal of a password is blocked for upload-only links
+
 @property(readonly,nullable,nonatomic) OCCapabilityBool publicSharingExpireDateAddDefaultDate; //!< Controls whether a *default* expiration date should be set
 @property(readonly,nullable,nonatomic) OCCapabilityBool publicSharingExpireDateEnforceDateAndDaysDeterminesLastAllowedDate; //!< Controls whether .publicSharingDefaultExpireDateDays is enforced as maximum expiration date. Also, when set, an expiration date is REQUIRED.
 @property(readonly,nullable,nonatomic) NSNumber *publicSharingDefaultExpireDateDays;

--- a/ownCloudSDK/Connection/Capabilities/OCCapabilities.m
+++ b/ownCloudSDK/Connection/Capabilities/OCCapabilities.m
@@ -20,6 +20,8 @@
 #import "OCMacros.h"
 #import "OCConnection.h"
 
+#define WithDefault(val,def) (((val)==nil)?(def):(val))
+
 static NSInteger _defaultSharingSearchMinLength = 2;
 
 @interface OCCapabilities()
@@ -101,6 +103,11 @@ static NSInteger _defaultSharingSearchMinLength = 2;
 @dynamic publicSharingPasswordEnforcedForReadWrite;
 @dynamic publicSharingPasswordEnforcedForReadWriteDelete;
 @dynamic publicSharingPasswordEnforcedForUploadOnly;
+@dynamic publicSharingPasswordBlockRemovalForReadOnly;
+@dynamic publicSharingPasswordBlockRemovalForReadWrite;
+@dynamic publicSharingPasswordBlockRemovalForReadWriteDelete;
+@dynamic publicSharingPasswordBlockRemovalForUploadOnly;
+
 @dynamic publicSharingExpireDateAddDefaultDate;
 @dynamic publicSharingExpireDateEnforceDateAndDaysDeterminesLastAllowedDate;
 @dynamic publicSharingDefaultExpireDateDays;
@@ -655,6 +662,26 @@ static NSInteger _defaultSharingSearchMinLength = 2;
 - (OCCapabilityBool)publicSharingPasswordEnforcedForUploadOnly
 {
 	return (OCTypedCast(_capabilities[@"files_sharing"][@"public"][@"password"][@"enforced_for"][@"upload_only"], NSNumber));
+}
+
+- (OCCapabilityBool)publicSharingPasswordBlockRemovalForReadOnly
+{
+	return (WithDefault(OCTypedCast(_capabilities[@"files_sharing"][@"public"][@"password"][@"block_password_removal"][@"read_only"], NSNumber), @NO));
+}
+
+- (OCCapabilityBool)publicSharingPasswordBlockRemovalForReadWrite
+{
+	return (WithDefault(OCTypedCast(_capabilities[@"files_sharing"][@"public"][@"password"][@"block_password_removal"][@"read_write"], NSNumber), @NO));
+}
+
+- (OCCapabilityBool)publicSharingPasswordBlockRemovalForReadWriteDelete
+{
+	return (WithDefault(OCTypedCast(_capabilities[@"files_sharing"][@"public"][@"password"][@"block_password_removal"][@"read_write_delete"], NSNumber), @NO));
+}
+
+- (OCCapabilityBool)publicSharingPasswordBlockRemovalForUploadOnly
+{
+	return (WithDefault(OCTypedCast(_capabilities[@"files_sharing"][@"public"][@"password"][@"block_password_removal"][@"upload_only"], NSNumber), @NO));
 }
 
 - (OCCapabilityBool)publicSharingExpireDateAddDefaultDate


### PR DESCRIPTION
## Description
- OCCapabilities: add support for block_password_removal extension of password policy capabilities

A password policy block with that extension would look like:
```
"password": {
    "enforced_for": {
        "read_only": true,
        "read_write": true,
        "read_write_delete": true,
        "upload_only": true
    },
    "block_password_removal": {
        "read_only": false,
        "read_write": false,
        "read_write_delete": false,
        "upload_only": false
    },
    "enforced": false
},
```

To fulfill requirements (https://github.com/owncloud/ios-app/issues/1429), the SDK returns a default value of `false` for all `block_password_removal` values not found in a server's capabilities.

## Related Issue
https://github.com/owncloud/ios-app/issues/1429

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
