### PR TITLE
[feature/security-first-mdm] Add MDM/branding control over block_password_removal default value

### DIFF
--- a/ownCloudSDK/Connection/Capabilities/OCCapabilities.m
+++ b/ownCloudSDK/Connection/Capabilities/OCCapabilities.m
@@ -19,6 +19,7 @@
 #import "OCCapabilities.h"
 #import "OCMacros.h"
 #import "OCConnection.h"
+#import "NSObject+OCClassSettings.h"
 
 #define WithDefault(val,def) (((val)==nil)?(def):(val))
 
@@ -664,24 +665,29 @@ static NSInteger _defaultSharingSearchMinLength = 2;
 	return (OCTypedCast(_capabilities[@"files_sharing"][@"public"][@"password"][@"enforced_for"][@"upload_only"], NSNumber));
 }
 
+- (OCCapabilityBool)_blockPasswordRemovalDefault
+{
+	return ([OCConnection classSettingForOCClassSettingsKey:OCConnectionBlockPasswordRemovalDefault]);
+}
+
 - (OCCapabilityBool)publicSharingPasswordBlockRemovalForReadOnly
 {
-	return (WithDefault(OCTypedCast(_capabilities[@"files_sharing"][@"public"][@"password"][@"block_password_removal"][@"read_only"], NSNumber), @NO));
+	return (WithDefault(OCTypedCast(_capabilities[@"files_sharing"][@"public"][@"password"][@"block_password_removal"][@"read_only"], NSNumber), self._blockPasswordRemovalDefault));
 }
 
 - (OCCapabilityBool)publicSharingPasswordBlockRemovalForReadWrite
 {
-	return (WithDefault(OCTypedCast(_capabilities[@"files_sharing"][@"public"][@"password"][@"block_password_removal"][@"read_write"], NSNumber), @NO));
+	return (WithDefault(OCTypedCast(_capabilities[@"files_sharing"][@"public"][@"password"][@"block_password_removal"][@"read_write"], NSNumber), self._blockPasswordRemovalDefault));
 }
 
 - (OCCapabilityBool)publicSharingPasswordBlockRemovalForReadWriteDelete
 {
-	return (WithDefault(OCTypedCast(_capabilities[@"files_sharing"][@"public"][@"password"][@"block_password_removal"][@"read_write_delete"], NSNumber), @NO));
+	return (WithDefault(OCTypedCast(_capabilities[@"files_sharing"][@"public"][@"password"][@"block_password_removal"][@"read_write_delete"], NSNumber), self._blockPasswordRemovalDefault));
 }
 
 - (OCCapabilityBool)publicSharingPasswordBlockRemovalForUploadOnly
 {
-	return (WithDefault(OCTypedCast(_capabilities[@"files_sharing"][@"public"][@"password"][@"block_password_removal"][@"upload_only"], NSNumber), @NO));
+	return (WithDefault(OCTypedCast(_capabilities[@"files_sharing"][@"public"][@"password"][@"block_password_removal"][@"upload_only"], NSNumber), self._blockPasswordRemovalDefault));
 }
 
 - (OCCapabilityBool)publicSharingExpireDateAddDefaultDate

--- a/ownCloudSDK/Connection/OCConnection.h
+++ b/ownCloudSDK/Connection/OCConnection.h
@@ -474,6 +474,7 @@ extern OCClassSettingsKey OCConnectionPlainHTTPPolicy; //!< Either "warn" (for O
 extern OCClassSettingsKey OCConnectionAlwaysRequestPrivateLink; //!< Controls whether private links are requested with regular PROPFINDs.
 extern OCClassSettingsKey OCConnectionTransparentTemporaryRedirect; //!< Allows (TRUE) transparent handling of 307 redirects at the HTTP pipeline level.
 extern OCClassSettingsKey OCConnectionValidatorFlags; //!< Allows fine-tuning the behavior of the connection validator.
+extern OCClassSettingsKey OCConnectionBlockPasswordRemovalDefault; //!< Controls the value of the `block_password_removal`-based capabilities if the server provides no value for it. This controls whether passwords can be removed from an existing link even though passwords need to be enforced on creation as per capabilities.
 
 extern OCConnectionOptionKey OCConnectionOptionRequestObserverKey;
 extern OCConnectionOptionKey OCConnectionOptionLastModificationDateKey; //!< Last modification date for uploads

--- a/ownCloudSDK/Connection/OCConnection.m
+++ b/ownCloudSDK/Connection/OCConnection.m
@@ -111,7 +111,8 @@ INCLUDE_IN_CLASS_SETTINGS_SNAPSHOTS(OCConnection)
 		OCConnectionPlainHTTPPolicy,
 		OCConnectionAlwaysRequestPrivateLink,
 		OCConnectionTransparentTemporaryRedirect,
-		OCConnectionValidatorFlags
+		OCConnectionValidatorFlags,
+		OCConnectionBlockPasswordRemovalDefault
 	]);
 }
 
@@ -154,7 +155,8 @@ INCLUDE_IN_CLASS_SETTINGS_SNAPSHOTS(OCConnection)
 		OCConnectionAllowCellular			: @(YES),
 		OCConnectionPlainHTTPPolicy			: @"warn",
 		OCConnectionAlwaysRequestPrivateLink		: @(NO),
-		OCConnectionTransparentTemporaryRedirect	: @(NO)
+		OCConnectionTransparentTemporaryRedirect	: @(NO),
+		OCConnectionBlockPasswordRemovalDefault		: @(YES)
 	});
 }
 
@@ -349,6 +351,14 @@ INCLUDE_IN_CLASS_SETTINGS_SNAPSHOTS(OCConnection)
 			OCClassSettingsMetadataKeyCategory	: @"Security",
 			OCClassSettingsMetadataKeyFlags		: @(OCClassSettingsFlagDenyUserPreferences)
 		},
+
+		OCConnectionBlockPasswordRemovalDefault : @{
+			OCClassSettingsMetadataKeyType 		: OCClassSettingsMetadataTypeBoolean,
+			OCClassSettingsMetadataKeyDescription 	: @"If a server does not provide `block_password_removal` information as part of its capabilities, this option provides the fallback value controlling whether passwords can (value: false) or can not (value: true) be removed from an existing link even if capabilities otherwise indicate passwords need to be enforced for links.",
+			OCClassSettingsMetadataKeyStatus	: OCClassSettingsKeyStatusAdvanced,
+			OCClassSettingsMetadataKeyCategory	: @"Security",
+			OCClassSettingsMetadataKeyFlags		: @(OCClassSettingsFlagDenyUserPreferences)
+		}
 	});
 }
 
@@ -3400,6 +3410,7 @@ OCClassSettingsKey OCConnectionPlainHTTPPolicy = @"plain-http-policy";
 OCClassSettingsKey OCConnectionAlwaysRequestPrivateLink = @"always-request-private-link";
 OCClassSettingsKey OCConnectionTransparentTemporaryRedirect = @"transparent-temporary-redirect";
 OCClassSettingsKey OCConnectionValidatorFlags = @"validator-flags";
+OCClassSettingsKey OCConnectionBlockPasswordRemovalDefault = @"block-password-removal-default";
 
 OCConnectionOptionKey OCConnectionOptionRequestObserverKey = @"request-observer";
 OCConnectionOptionKey OCConnectionOptionLastModificationDateKey = @"last-modification-date";


### PR DESCRIPTION
## Description
SDK changes underpinning https://github.com/owncloud/ios-app/pull/1444

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
