### PR TITLE
[fix/delete-share-error-handling] Extend delete share error handling

### DIFF
--- a/ownCloudSDK/Connection/OCConnection+Sharing.m
+++ b/ownCloudSDK/Connection/OCConnection+Sharing.m
@@ -48,6 +48,7 @@
 #import "OCShare+GraphAPI.h"
 #import "GASharingLink.h"
 #import "GASharingLinkPassword.h"
+#import "OCODataDecoder.h"
 
 @implementation OCConnection (Sharing)
 
@@ -702,6 +703,20 @@
 					// Share couldn't be deleted
 					event.error = OCError(OCErrorShareNotFound);
 				break;
+
+				case OCHTTPStatusCodeFORBIDDEN:
+					{
+						NSDictionary* jsonObj = [request.httpResponse bodyConvertedDictionaryFromJSONWithError:NULL];
+						if ((jsonObj != nil) && (jsonObj[@"error"] != nil))
+						{
+							OCODataResponse *response = [OCODataDecoder decodeODataResponse:jsonObj entityClass:Nil options:Nil];
+							if (response.error != nil)
+							{
+								event.error = response.error;
+								break;
+							}
+						}
+					}
 
 				default:
 					// Unknown error


### PR DESCRIPTION
## Description
Adds handling of FORBIDDEN status code for deleting shares, leveraging JSON/OData error response parsing in case the response also contains JSON error information.

## Related Issue
https://github.com/owncloud/ios-app/pull/1435#issuecomment-2769075643

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
