### PR TITLE
[fix/normalize-openssl-version] Bring OpenSSL version on par with ios-app

### DIFF
--- a/ownCloudSDK.xcodeproj/project.pbxproj
+++ b/ownCloudSDK.xcodeproj/project.pbxproj
@@ -6490,7 +6490,7 @@
 			repositoryURL = "https://github.com/krzyzanowskim/OpenSSL.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 3.1.5006;
+				minimumVersion = 3.3.2000;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
## Description
Bumps minimum version of OpenSSL SwiftPM package to 3.3.200…0 - on par with ios-app.

## Related Issue
Fixes a discrepancy noticed in https://github.com/owncloud/ios-app/pull/1474

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
