### PR TITLE
ci: pin all GitHub Actions to SHA for org security policy

### DIFF
--- a/.github/workflows/push-transifex.yml
+++ b/.github/workflows/push-transifex.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: l10n-format
         shell: bash
@@ -23,7 +23,7 @@ jobs:
           beautifyJSON "ownCloudUI/Resources/Localizable.xcstrings"
 
       - name: l10n-push-source
-        uses: transifex/cli-action@v2
+        uses: transifex/cli-action@584fd205cbe598773b5a81ce711fa44842678189 # v2
         with:
           token: ${{ secrets.TX_TOKEN }}
           args: push -s --skip


### PR DESCRIPTION
## Summary

Pins all GitHub Actions workflow steps to full commit SHAs to comply with the org's SHA-pinning policy.

## Test plan
- [ ] Verify CI workflows run successfully after the pin changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)