### PR TITLE
docs(ospo): community health rollout v2 — README, agents.md, health files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+This project follows the ownCloud Code of Conduct.
+
+Please read the full Code of Conduct at:
+**<https://owncloud.com/contribute/code-of-conduct/>**
+
+By participating in this project, you agree to abide by its terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+Thank you for your interest in contributing to this project!
+
+Please read the full contributing guidelines at:
+**<https://owncloud.com/contribute/>**
+
+For development setup, coding standards, and pull request process,
+see the README in this repository.

--- a/README.md
+++ b/README.md
@@ -1,62 +1,112 @@
-#  ownCloud iOS SDK
+# ownCloud iOS SDK
 
-## Introduction
+<!-- OSPO-managed README | Generated: 2026-04-16 | v2 -->
 
-A new, modern ownCloud iOS SDK.
+[![License](https://img.shields.io/badge/License-GPL--3.0-blue.svg)](LICENSE) [![ownCloud OSPO](https://img.shields.io/badge/OSPO-ownCloud-blue)](https://kiteworks.com/opensource)
 
-## Architecture
-(this section is not entirely up-to-date)
+A modern iOS SDK framework that provides a complete abstraction layer for communicating with ownCloud servers. It handles connection management, authentication (including OAuth2), file operations, database caching via OCVault/OCDatabase, sharing, and background transfers -- all exposed through a transactional query-based API (OCCore/OCQuery) designed for building responsive, animated user interfaces.
 
-![New architecture](doc/new-architecture.png)
+## Getting Started
 
-The iOS SDK comes as a framework that is easy to integrate and encapsulates all needed code and resources.
+Follow the steps below to integrate the SDK into your project.
 
-- `OCBookmark` objects contain the name and URL of an ownCloud server. It also transparently stores and provides access to credentials/tokens (e.g. OAuth2 tokens) in the iOS keychain for use with an `OCAuthenticationMethod`. Bookmark objects are used to initialize a Core (see below). Bookmark objects can also be serialized for permanently storing references to a user's servers.
+### Prerequisites
 
-- `OCConnection` objects are responsible for forming HTTP(S) and WebDAV requests, sending them to the ownCloud server (identified by a bookmark), parsing the result and returning the result back to the Core as an `OCEvent`. It also is responsible for establishing the authenticity of the server and notifying the Core about any issues it finds. In case of issues, the Core can consult with a delegate (usually implemented by the app using the SDK) and then instruct the Connection on whether to proceed or not.
+- Xcode (latest stable)
+- iOS 16+ deployment target
 
-- `OCDatabase` objects are responsible for storing cached information on disk and providing the Core access to it. It is also responsible for storing local copies of files. On disk, one database is used per vault/bookmark.
+### Integration
 
-- `OCVault` objects provide and manage all local storage associated with a bookmark, including storage for cached thumbnails, databases, files and folders available offline. Typically, one folder is created per vault, which then organizes its data inside that folder. Since every bookmark has its own vault, removing _all_ resources related to a bookmark can be achieved simply by deleting the root directory of the vault. OCVault objects are initialized with a bookmark and usually use the bookmark's UUID to locate the vault directory and database.
+Add the SDK as a submodule or Swift Package dependency:
 
-- `OCQuery` objects provide an interface between the Core and apps. They encapsulate a long-running query that provides:
-    - the path of the file or directory the query targets
-    - filtering (via objects conforming to the `OCQueryFilter` protocol, a convenience class for using blocks is provided) that limit which items are returned (can be used to implement search or particular perspectives)
-    - sorting via a NSComparator block that defines the order of the query results
-    - the query's state: "idle" (no changes), "contents from cache" (results come from the database), "updating" (a request has been sent to the server - updates possible at any time)
-    - "live" array of all items matching the query (queryResults).
-    - a mechanism to notify a delegate (`OCQueryDelegate`) of changes, effectively providing a transactional view of changes as coalescated `OCQueryChangeSet` objects that can be used to implement animated UIs or efficient tracking of changes.
+```bash
+git submodule add https://github.com/owncloud/ios-sdk.git
+```
 
-- `OCItem` objects encapsulate metadata, status information and shares (see next point) about directories and files.
+Then add the `ownCloudSDK.xcodeproj` to your workspace and link the framework.
 
-- `OCShare` objects encapsulate all metadata of shared links, users with whom a file/directory was shared as well as users by whom a file/directory was shared.
+## Documentation
 
-- **Commands** are methods provided by the Core to asynchronously perform file operations such as copy, move, rename, delete, download, upload and retrieving thumbnails. Apps pass in Item objects and a completion handler. When the file operation has finished, the completion handler is called and related queries updated accordingly. Command methods can return an `NSProgress` that provides status information and the ability to cancel a running or scheduled command.
+- [Architecture Overview](doc/new-architecture.png)
+- [iOS App Documentation](https://doc.owncloud.com/ios-app/)
 
-- `OCCore` objects tie everything together. When a new Query is added to a core, it consults the Database for immediate results - and makes requests to the server using the Connection as needed.
+## Part of the ownCloud Mobile Ecosystem
 
-    When the Connection returns results, the Core runs through all running Queries, checks if the result relates to them, updates the Query's items as necessary and finally notifies the `OCQueryDelegate` that results have changed.
+This SDK is the foundation for the [ownCloud iOS app](https://github.com/owncloud/ios-app). It ships as an embeddable framework for integration into any iOS/macOS application that needs to interact with ownCloud.
 
-    It also coalesces changes, so that when a query's owner gets around to fetching the changes, the change set is as compact as possible.
+## Community & Support
 
-### OCCore / OCConnection event handling, background transfers & persisting associated data
+**[Star](https://github.com/owncloud/ios-sdk)** this repo and **Watch** for release notifications!
 
-A hybrid solution is needed to fully leverage background transfers while making a rich, block-based API available. The `OCEvent` set of classes and types offers a solution for this.
+- [ownCloud Website](https://owncloud.com)
+- [Community Discussions](https://github.com/orgs/owncloud/discussions)
+- [Matrix Chat](https://app.element.io/#/room/#owncloud:matrix.org)
+- [Documentation](https://doc.owncloud.com)
+- [Enterprise Support](https://owncloud.com/contact-us/)
+- [OSPO Home](https://kiteworks.com/opensource)
 
-Here's how it works:
-- When `OCCore` receives a command, it creates a new  `OCEventTarget` object that stores all contextual data needed to handle the response in the  `userInfo` property - and all other objects that can't be persisted (like completionHandler blocks) in  `ephermalUserInfo`.
-- `OCCore` subsequently calls the `OCConnection` method corresponding to the command it received and passes it the `OCEventTarget` object that encapsulates everything it needs to make sense of the reply as well as a globally unique event handler identifier (`OCEventHandlerIdentifier`) allowing `OCConnection` to reconnect to `OCCore` if the app was intermittently terminated.
-- When `OCConnection` has processed the command, it generates an `OCEvent` using the `OCEventTarget` and sends it back to the `OCCore` using the core's unique event handler identifier (`OCEventHandlerIdentifier`)
-- `OCCore` then has a chance to re-associate the event with the completion handler it stored earlier - and call it.
+## Contributing
 
-For background transfers, where the app could be terminated while a background `NSURLSession` still processes requests:
-- `OCCore` can process the outcome of the requests (and update the database and files accordingly) independently from the existance of a completion handler.
-- `OCCore` also has a chance to store additonal information it needs to process the outcome of a request: by storing that data in the `userInfo` field of the `OCEventTarget`. As it receives the result of the request as an `OCEvent`, it also gets passed back the  `userInfo`.
+We welcome contributions! Please read the [Contributing Guidelines](CONTRIBUTING.md)
+and our [Code of Conduct](CODE_OF_CONDUCT.md) before getting started.
 
-Note: since `OCEventTarget` handles the resolution and actual delivery of the event to the target, support for different mechanisms (f.ex. direct delivery to a block) can be added relatively easy through subclassing.
+### Workflow
+
+- **Rebase Early, Rebase Often!** We use a rebase workflow. Always rebase on the target branch before submitting a PR.
+- **Dependabot**: Automated dependency updates are managed via Dependabot. Review and merge dependency PRs promptly.
+- **Signed Commits**: All commits **must** be PGP/GPG signed. See [GitHub's signing guide](https://docs.github.com/en/authentication/managing-commit-signature-verification).
+- **DCO Sign-off**: Every commit must carry a `Signed-off-by` line:
+  ```
+  git commit -s -S -m "your commit message"
+  ```
+- **GitHub Actions Policy**: Workflows may only use actions that are (a) owned by `owncloud`, (b) created by GitHub (`actions/*`), or (c) verified in the GitHub Marketplace.
+
+## Translations
+
+Help translate this project on Transifex:
+**<https://explore.transifex.com/owncloud-org/owncloud-ios/>**
+
+Please submit translations via Transifex -- do not open pull requests for translation changes.
+
+## Security
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities at **<https://security.owncloud.com>** -- see [SECURITY.md](SECURITY.md).
+
+Bug bounty: [YesWeHack ownCloud Program](https://yeswehack.com/programs/owncloud-bug-bounty-program)
 
 ## License
 
-This project is currently licensed under GPL v3.
-We do provide support as well as an option for a dual-licensing as part of our ownCloud Enterprise subscriptions. Please contact info@owncloud.com for more information.
+This project is licensed under the [GPL-3.0](LICENSE).
 
+## About the ownCloud OSPO
+
+The [Kiteworks Open Source Program Office](https://kiteworks.com/opensource), operating under
+the [ownCloud](https://owncloud.com) brand, launched on May 5, 2026, to steward the open source
+ecosystem around ownCloud's products. The OSPO ensures transparent governance, license compliance,
+community health, and sustainable collaboration between the open source community and
+[Kiteworks](https://www.kiteworks.com), which acquired ownCloud in 2023.
+
+- **OSPO Home**: <https://kiteworks.com/opensource>
+- **GitHub**: <https://github.com/owncloud>
+- **ownCloud**: <https://owncloud.com>
+
+For questions about the OSPO or licensing, contact ospo@kiteworks.com.
+
+### License Migration to Apache 2.0
+
+The OSPO is driving a strategic relicensing of ownCloud repositories toward the
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), following
+the [Apache Software Foundation's third-party license policy](https://www.apache.org/legal/resolved.html).
+
+Individual repositories will migrate as their audit is completed. The LICENSE file
+in each repo reflects its **current** license status (not the target).
+
+**Current license: GPL-3.0** (Category X per Apache policy -- cannot be included in Apache-2.0 works).
+
+Migration prerequisites for this repository:
+
+- **CLA/DCO coverage**: All past contributors must have signed agreements permitting relicensing
+- **Copyleft dependency audit**: All GPL dependencies must be replaced or isolated
+- **Complete relicensing**: GPL-3.0 is a strong copyleft license; migration requires full relicensing of all files

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Please report security issues responsibly via:
+**<https://security.owncloud.com>**
+
+You can also report vulnerabilities through our YesWeHack bug bounty program:
+**<https://yeswehack.com/programs/owncloud-bug-bounty-program>**

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,10 @@
+# Support
+
+For support with this project, please use the following channels:
+
+- **Enterprise Support**: <https://owncloud.com/contact-us/>
+- **Community discussions**: https://github.com/orgs/owncloud/discussions
+- **Matrix Chat**: <https://app.element.io/#/room/#owncloud:matrix.org>
+- **Documentation**: <https://doc.owncloud.com>
+
+Please do not use GitHub issues for general support questions.

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,59 @@
+# agents.md -- ownCloud iOS SDK
+
+## Repository Overview
+
+Modern iOS SDK framework providing a complete abstraction layer for ownCloud server communication. Written in Objective-C and Swift. Licensed under GPL-3.0.
+
+## Architecture & Key Paths
+
+- `ownCloudSDK/` -- Core SDK source code
+- `ownCloudSDKTests/` -- SDK unit tests
+- `ownCloudSDK.xcodeproj/` -- Xcode project
+- `ownCloudMocking/` -- Mocking framework for tests
+- `ownCloudMockingTests/` -- Mocking framework tests
+- `ownCloudUI/` -- UI components
+- `Example/` -- Example app
+- `tools/` -- Development tools
+- `doc/` -- Architecture documentation
+
+## Development Conventions
+
+- Mixed Objective-C and Swift codebase
+- Xcode project-based build system
+- Modular architecture: OCCore, OCConnection, OCVault, OCQuery, OCDatabase
+
+## Build & Test Commands
+
+```bash
+# Open ownCloudSDK.xcodeproj in Xcode
+# Run tests via Xcode Test Navigator (Cmd+U)
+```
+
+## Important Constraints
+
+- Licensed under GPL-3.0 (copyleft). Apache 2.0 migration planned.
+- This SDK is a dependency of the ownCloud iOS app (used as a submodule).
+- All contributions require a DCO sign-off.
+
+
+## OSPO Policy Constraints
+
+### GitHub Actions
+- **Only** use actions owned by `owncloud`, created by GitHub (`actions/*`), verified on the GitHub Marketplace, or verified by the ownCloud Maintainers.
+- Pin all actions to their full commit SHA (not tags): `uses: actions/checkout@<SHA> # vX.Y.Z`
+- Never introduce actions from unverified third parties.
+
+### Dependency Management
+- Dependabot is configured for automated dependency updates.
+- Review and merge Dependabot PRs as part of regular maintenance.
+- Do not introduce new dependencies without discussion in an issue first.
+
+### Git Workflow
+- **Rebase policy**: Always rebase; never create merge commits. Use `git pull --rebase` and `git rebase` before pushing.
+- **Signed commits**: All commits **must** be PGP/GPG signed (`git commit -S -s`).
+- **DCO sign-off**: Every commit needs a `Signed-off-by` line (`git commit -s`).
+- **Conventional Commits & Squash Merge**: Use the [Conventional Commits](https://www.conventionalcommits.org/) format where the repository enforces it. Many repos use squash merge, where the PR title becomes the commit message on the default branch — apply Conventional Commits format to PR titles as well. A reusable GitHub Actions workflow enforces this.
+
+## Context for AI Agents
+
+The SDK follows a Core/Connection/Vault/Query architecture. OCCore ties together OCConnection (HTTP/WebDAV), OCDatabase (caching), and OCVault (local storage). OCQuery provides a reactive, transactional interface for building animated UIs. Changes should preserve the event-driven architecture using OCEvent/OCEventTarget patterns.


### PR DESCRIPTION
## Summary

This PR is part of the **Kiteworks OSPO community health rollout** ([kiteworks.com/opensource](https://kiteworks.com/opensource)), applied to all ~110 public ownCloud repositories starting May 5, 2026.

- **README.md**: Rewritten with v2 OSPO template
  * License-specific OSPO section with Apache 2.0 migration guidance
  * Mandatory Community & Support section: GitHub Discussions, Matrix, docs, enterprise support, OSPO home
  * Contributing workflow: Rebase Early/Often, Dependabot, PGP/GPG-signed commits, DCO sign-off, GitHub Actions policy
  * Security section pointing to security.owncloud.com + YesWeHack bug bounty
  * Translations link to Transifex ([owncloud project](https://explore.transifex.com/owncloud-org/owncloud/))
- **agents.md** *(new)*: AI agent context file with architecture, build commands, OSPO policy constraints
- **CODE_OF_CONDUCT.md** *(new)*: Redirect to <https://owncloud.com/contribute/code-of-conduct/>
- **CONTRIBUTING.md** *(new)*: Redirect to <https://owncloud.com/contribute/>
- **SECURITY.md** *(new)*: Redirect to <https://security.owncloud.com> + YesWeHack
- **SUPPORT.md** *(new)*: Redirect to <https://owncloud.com/contact-us/> and support channels

## Test plan

- [ ] README renders correctly on GitHub (badges, sections, links)
- [ ] All health file links resolve (CODE_OF_CONDUCT, CONTRIBUTING, SECURITY, SUPPORT)
- [ ] agents.md loads correctly in Claude Code and GitHub Copilot
- [ ] License referenced in README matches actual LICENSE file in repo

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) as part of the ownCloud OSPO rollout.
Kiteworks OSPO: <https://kiteworks.com/opensource>